### PR TITLE
fix endianness in +max, +min, +ravel

### DIFF
--- a/lagoon/desk/lib/lagoon.hoon
+++ b/lagoon/desk/lib/lagoon.hoon
@@ -265,7 +265,7 @@
     ~/  %ravel
     |=  a=ray
     ^-  (list @)
-    (flop (snip (rip bloq.meta.a data.a)))
+    (snip (rip bloq.meta.a data.a))
   ::
   ++  en-ray    :: baum to ray
     |=  =baum
@@ -581,7 +581,7 @@
     |=  a=ray
     =/  fun
       |:  [b=1 c=-:(ravel a)] 
-      ?:  =(((fun-scalar meta.a %gth) b c) 0)
+      ?:  =(((fun-scalar meta.a %gth) b c) .1)
         b  c 
     (scalar-to-ray meta.a (reel (ravel a) fun))
   ::
@@ -596,7 +596,7 @@
     |=  a=ray
     =/  fun
       |:  [b=1 c=-:(ravel a)] 
-      ?:  =(((fun-scalar meta.a %lth) b c) 0)
+      ?:  =(((fun-scalar meta.a %lth) b c) .1)
         b  c 
     (scalar-to-ray meta.a (reel (ravel a) fun))
   ::


### PR DESCRIPTION
Corrected behavior:
```
> ar
[ meta=[shape=[10 1 ~] bloq=5 kind=%real prec=~]
  data=0x1.4105.d2cb.4078.65e5.3f17.12ad.c107.fcae.4158.4844.be97.1567.408d.eef3.c117.1665.c111.cbb5.c0a6.6743
]
> `(list @rs)`(ravel:la:la ar)
~[.-5.200105 .-9.112233 .-9.442967 .4.4354186 .-0.29508516 .13.517643 .-8.499189 .0.5901287 .3.8812191 .8.363963]
> `@rs`data:(max:la:la ar)
.13.517643
> `@rs`data:(min:la:la ar)
.-9.442967
```