### PR TITLE
Revert "fix set-item and get-item"

### DIFF
--- a/lagoon/desk/lib/lagoon.hoon
+++ b/lagoon/desk/lib/lagoon.hoon
@@ -138,18 +138,20 @@
   ++  get-item  ::  extract item at index .dex
     |=  [=ray dex=(list @)]
     ^-  @ux
+    =/  len  (^sub (roll shape.meta.ray ^mul) 1)
     %^    cut
         bloq.meta.ray
-      [(get-bloq-offset meta.ray dex) 1]
+      [(^sub len (get-bloq-offset meta.ray dex)) 1]
     data.ray
   ::
   ++  set-item  ::  set item at index .dex to .val
     |=  [=ray dex=(list @) val=@]
     ^+  ray
+    =/  len  (^sub (roll shape.meta.ray ^mul) 1)
     :-  meta.ray
     %^    sew
         bloq.meta.ray
-      [(get-bloq-offset meta.ray dex) 1 val]
+      [(^sub len (get-bloq-offset meta.ray dex)) 1 val]
     data.ray
   ::
   ++  get-row


### PR DESCRIPTION
Reverts urbit/numerics#3, which introduced some endianness issues.

```
++  test-set-item-2d  ^-  tang
  =/  input-meta  [shape=~[3 3] bloq=4 kind=%uint prec=~]
  =/  input-magic-3x3-4u  (magic:la input-meta)
  ;:  weld
    %+  expect-eq
      !>((en-ray:la input-meta ~[~[0xf 0x1 0x2] ~[0x3 0x4 0x5] ~[0x6 0x7 0x8]]))
      !>((set-item:la input-magic-3x3-4u ~[0 0] 0xf))
    %+  expect-eq
      !>((en-ray:la input-meta ~[~[0x0 0x1 0x2] ~[0x3 0xf 0x5] ~[0x6 0x7 0x8]]))
      !>((set-item:la input-magic-3x3-4u ~[1 1] 0xf))
    %+  expect-eq
      !>((en-ray:la input-meta ~[~[0x0 0x1 0x2] ~[0x3 0x4 0x5] ~[0x6 0xf 0x8]]))
      !>((set-item:la input-magic-3x3-4u ~[2 1] 0xf))
    %-  expect-fail
      |.((set-item:la input-magic-3x3-4u ~[3 3] 0xf))
  ==
```

fails now with

```
>   test-set-item-1d: took ms/63.839
FAILED  /tests/lib/lagoon-array-utils/test-set-item-1d
  expected
[meta=[shape=~[8] bloq=3 kind=%uint fxp=~] data=0x1.0f01.0203.0405.0607]
  actual  
[meta=[shape=~[8] bloq=3 kind=%uint fxp=~] data=0x1.0001.0203.0405.060f]
  expected
[meta=[shape=~[8] bloq=3 kind=%uint fxp=~] data=0x1.0001.0203.0405.060f]
  actual  
[meta=[shape=~[8] bloq=3 kind=%uint fxp=~] data=0x1.0f01.0203.0405.0607]
  expected
[meta=[shape=~[8] bloq=3 kind=%uint fxp=~] data=0x1.0001.020f.0405.0607]
  actual  
[meta=[shape=~[8] bloq=3 kind=%uint fxp=~] data=0x1.0001.0203.0f05.0607]
```