### PR TITLE
Fix sub jet to return the computed result buffer

### DIFF
--- a/lagoon/desk/tests/lib/lagoon-double-args-elementwise.hoon
+++ b/lagoon/desk/tests/lib/lagoon-double-args-elementwise.hoon
@@ -689,6 +689,47 @@
     canon-add-3x3-6u
   assay-add-3x3-6u
 ::
+::  Asymmetric regression tests for sub: x - y with x != y, where the
+::  expected result distinguishes the correct answer from every known
+::  failure mode (returning unmodified y, returning x, or computing y - x).
+::  See the x_bytes/y_bytes swap in the ?axpy jets.  x=[5 2], y=[3 1] so
+::  x - y = [2 1]; the failure modes would yield [3 1], [5 2], or [-2 -1].
+++  test-sub-asym-1x2-4r  ^-  tang
+  =/  input-sub-asym-1x2-4r  (en-ray:la [meta=[shape=~[1 2] bloq=4 kind=%i754 tail=~] baum=~[~[.~~5.0 .~~2.0]]])
+  =/  jnput-sub-asym-1x2-4r  (en-ray:la [meta=[shape=~[1 2] bloq=4 kind=%i754 tail=~] baum=~[~[.~~3.0 .~~1.0]]])
+  =/  canon-sub-asym-1x2-4r  (en-ray:la [meta=[shape=~[1 2] bloq=4 kind=%i754 tail=~] baum=~[~[.~~2.0 .~~1.0]]])
+  =/  assay-sub-asym-1x2-4r  (sub:la input-sub-asym-1x2-4r jnput-sub-asym-1x2-4r)
+  %+  is-equal
+    canon-sub-asym-1x2-4r
+  assay-sub-asym-1x2-4r
+::
+++  test-sub-asym-1x2-5r  ^-  tang
+  =/  input-sub-asym-1x2-5r  (en-ray:la [meta=[shape=~[1 2] bloq=5 kind=%i754 tail=~] baum=~[~[.5.0 .2.0]]])
+  =/  jnput-sub-asym-1x2-5r  (en-ray:la [meta=[shape=~[1 2] bloq=5 kind=%i754 tail=~] baum=~[~[.3.0 .1.0]]])
+  =/  canon-sub-asym-1x2-5r  (en-ray:la [meta=[shape=~[1 2] bloq=5 kind=%i754 tail=~] baum=~[~[.2.0 .1.0]]])
+  =/  assay-sub-asym-1x2-5r  (sub:la input-sub-asym-1x2-5r jnput-sub-asym-1x2-5r)
+  %+  is-equal
+    canon-sub-asym-1x2-5r
+  assay-sub-asym-1x2-5r
+::
+++  test-sub-asym-1x2-6r  ^-  tang
+  =/  input-sub-asym-1x2-6r  (en-ray:la [meta=[shape=~[1 2] bloq=6 kind=%i754 tail=~] baum=~[~[.~5.0 .~2.0]]])
+  =/  jnput-sub-asym-1x2-6r  (en-ray:la [meta=[shape=~[1 2] bloq=6 kind=%i754 tail=~] baum=~[~[.~3.0 .~1.0]]])
+  =/  canon-sub-asym-1x2-6r  (en-ray:la [meta=[shape=~[1 2] bloq=6 kind=%i754 tail=~] baum=~[~[.~2.0 .~1.0]]])
+  =/  assay-sub-asym-1x2-6r  (sub:la input-sub-asym-1x2-6r jnput-sub-asym-1x2-6r)
+  %+  is-equal
+    canon-sub-asym-1x2-6r
+  assay-sub-asym-1x2-6r
+::
+++  test-sub-asym-1x2-7r  ^-  tang
+  =/  input-sub-asym-1x2-7r  (en-ray:la [meta=[shape=~[1 2] bloq=7 kind=%i754 tail=~] baum=~[~[.~~~5.0 .~~~2.0]]])
+  =/  jnput-sub-asym-1x2-7r  (en-ray:la [meta=[shape=~[1 2] bloq=7 kind=%i754 tail=~] baum=~[~[.~~~3.0 .~~~1.0]]])
+  =/  canon-sub-asym-1x2-7r  (en-ray:la [meta=[shape=~[1 2] bloq=7 kind=%i754 tail=~] baum=~[~[.~~~2.0 .~~~1.0]]])
+  =/  assay-sub-asym-1x2-7r  (sub:la input-sub-asym-1x2-7r jnput-sub-asym-1x2-7r)
+  %+  is-equal
+    canon-sub-asym-1x2-7r
+  assay-sub-asym-1x2-7r
+::
 ++  test-sub-1x1-4r  ^-  tang
   =/  input-ones-1x1-4r  (en-ray:la [meta=[shape=~[1 1] bloq=4 kind=%i754 tail=~] baum=~[~[.~~1.0]]])
   =/  jnput-ones-1x1-4r  (en-ray:la [meta=[shape=~[1 1] bloq=4 kind=%i754 tail=~] baum=~[~[.~~1.0]]])

--- a/lagoon/vere/noun/jets/i/lagoon.c
+++ b/lagoon/vere/noun/jets/i/lagoon.c
@@ -203,16 +203,16 @@
     // syz_x is length in bytes
     c3_d syz_x = len_x * pow(2, bloq-3);
 
-    // x_bytes is the data array (w/o leading 0x1)
-    c3_y* x_bytes = (c3_y*)u3a_malloc(syz_x*sizeof(c3_y));
+    // x_bytes is the data array (w/ leading 0x1, skipped by ?axpy; holds result)
+    c3_y* x_bytes = (c3_y*)u3a_malloc((syz_x+1)*sizeof(c3_y));
     u3r_bytes(0, syz_x, x_bytes, x_data);
+    x_bytes[syz_x] = 0x1;
 
-    // y_bytes is the data array (w/ leading 0x1, skipped by ?axpy)
-    c3_y* y_bytes = (c3_y*)u3a_malloc((syz_x+1)*sizeof(c3_y));
+    // y_bytes is the data array (w/o leading 0x1)
+    c3_y* y_bytes = (c3_y*)u3a_malloc(syz_x*sizeof(c3_y));
     u3r_bytes(0, syz_x, y_bytes, y_data);
-    y_bytes[syz_x] = 0x1;
 
-    //  Switch on the block size.
+    //  Switch on the block size.  Computes x_bytes := -1*y + x = x - y.
     switch (u3x_atom(bloq)) {
       case 4:
         haxpy(len_x, (float16_t){SB_REAL16_NEGONE}, (float16_t*)y_bytes, 1, (float16_t*)x_bytes, 1);
@@ -232,7 +232,7 @@
     }
 
     // r_data is the result noun of [data]
-    u3_noun r_data = u3i_bytes((syz_x+1)*sizeof(c3_y), y_bytes);
+    u3_noun r_data = u3i_bytes((syz_x+1)*sizeof(c3_y), x_bytes);
 
     //  Clean up and return.
     u3a_free(x_bytes);

--- a/lagoon/vere64/noun/jets/lagoon.c
+++ b/lagoon/vere64/noun/jets/lagoon.c
@@ -204,15 +204,15 @@
     // syz_x is length in bytes
     c3_d syz_x = len_x * pow(2, bloq-3);
 
-    // x_bytes is the data array (w/o leading 0x1)
-    c3_y* x_bytes = (c3_y*)u3a_malloc(syz_x*sizeof(c3_y));
-    u3r_bytes(0, syz_x, x_bytes, x_data);
+    // x_bytes is the data array (w/ leading 0x1, skipped by ?axpy; holds result)
+    c3_y* x_bytes = (c3_y*)u3a_malloc((syz_x+1)*sizeof(c3_y));
+    u3r_bytes(0, syz_x+1, x_bytes, x_data);
 
-    // y_bytes is the data array (w/ leading 0x1, skipped by ?axpy)
-    c3_y* y_bytes = (c3_y*)u3a_malloc((syz_x+1)*sizeof(c3_y));
-    u3r_bytes(0, syz_x+1, y_bytes, y_data);
-    
-    //  Switch on the block size.
+    // y_bytes is the data array (w/o leading 0x1)
+    c3_y* y_bytes = (c3_y*)u3a_malloc(syz_x*sizeof(c3_y));
+    u3r_bytes(0, syz_x, y_bytes, y_data);
+
+    //  Switch on the block size.  Computes x_bytes := -1*y + x = x - y.
     switch (u3x_atom(bloq)) {
       case 4:
         haxpy(len_x, (float16_t){SB_REAL16_NEGONE}, (float16_t*)y_bytes, 1, (float16_t*)x_bytes, 1);
@@ -232,7 +232,7 @@
     }
 
     // r_data is the result noun of [data]
-    u3_noun r_data = u3i_bytes((syz_x+1)*sizeof(c3_y), y_bytes);
+    u3_noun r_data = u3i_bytes((syz_x+1)*sizeof(c3_y), x_bytes);
 
     //  Clean up and return.
     u3a_free(x_bytes);

--- a/maroon/desk/tests/lib/lagoon-double-args-elementwise.hoon
+++ b/maroon/desk/tests/lib/lagoon-double-args-elementwise.hoon
@@ -608,6 +608,38 @@
     canon-add-3x3-6u
   assay-add-3x3-6u
 ::
+::  Asymmetric regression tests for sub: x - y with x != y, where the
+::  expected result distinguishes the correct answer from every known
+::  failure mode (returning unmodified y, returning x, or computing y - x).
+::  See the x_bytes/y_bytes swap in the ?axpy jets.  x=[5 2], y=[3 1] so
+::  x - y = [2 1]; the failure modes would yield [3 1], [5 2], or [-2 -1].
+++  test-sub-asym-1x2-4r  ^-  tang
+  =/  input-sub-asym-1x2-4r  (en-ray:la [meta=[shape=~[1 2] bloq=4 kind=%real fxp=~] baum=~[~[.~~5.0 .~~2.0]]])
+  =/  jnput-sub-asym-1x2-4r  (en-ray:la [meta=[shape=~[1 2] bloq=4 kind=%real fxp=~] baum=~[~[.~~3.0 .~~1.0]]])
+  =/  canon-sub-asym-1x2-4r  (en-ray:la [meta=[shape=~[1 2] bloq=4 kind=%real fxp=~] baum=~[~[.~~2.0 .~~1.0]]])
+  =/  assay-sub-asym-1x2-4r  (sub:la input-sub-asym-1x2-4r jnput-sub-asym-1x2-4r)
+  %+  is-equal
+    canon-sub-asym-1x2-4r
+  assay-sub-asym-1x2-4r
+::
+++  test-sub-asym-1x2-5r  ^-  tang
+  =/  input-sub-asym-1x2-5r  (en-ray:la [meta=[shape=~[1 2] bloq=5 kind=%real fxp=~] baum=~[~[.5.0 .2.0]]])
+  =/  jnput-sub-asym-1x2-5r  (en-ray:la [meta=[shape=~[1 2] bloq=5 kind=%real fxp=~] baum=~[~[.3.0 .1.0]]])
+  =/  canon-sub-asym-1x2-5r  (en-ray:la [meta=[shape=~[1 2] bloq=5 kind=%real fxp=~] baum=~[~[.2.0 .1.0]]])
+  =/  assay-sub-asym-1x2-5r  (sub:la input-sub-asym-1x2-5r jnput-sub-asym-1x2-5r)
+  %+  is-equal
+    canon-sub-asym-1x2-5r
+  assay-sub-asym-1x2-5r
+::
+++  test-sub-asym-1x2-6r  ^-  tang
+  =/  input-sub-asym-1x2-6r  (en-ray:la [meta=[shape=~[1 2] bloq=6 kind=%real fxp=~] baum=~[~[.~5.0 .~2.0]]])
+  =/  jnput-sub-asym-1x2-6r  (en-ray:la [meta=[shape=~[1 2] bloq=6 kind=%real fxp=~] baum=~[~[.~3.0 .~1.0]]])
+  =/  canon-sub-asym-1x2-6r  (en-ray:la [meta=[shape=~[1 2] bloq=6 kind=%real fxp=~] baum=~[~[.~2.0 .~1.0]]])
+  =/  assay-sub-asym-1x2-6r  (sub:la input-sub-asym-1x2-6r jnput-sub-asym-1x2-6r)
+  %+  is-equal
+    canon-sub-asym-1x2-6r
+  assay-sub-asym-1x2-6r
+::
 ++  test-sub-1x1-4r  ^-  tang
   =/  input-ones-1x1-4r  (en-ray:la [meta=[shape=~[1 1] bloq=4 kind=%real fxp=~] baum=~[~[.~~1.0]]])
   =/  jnput-ones-1x1-4r  (en-ray:la [meta=[shape=~[1 1] bloq=4 kind=%real fxp=~] baum=~[~[.~~1.0]]])

--- a/maroon/vere/noun/jets/i/lagoon.c
+++ b/maroon/vere/noun/jets/i/lagoon.c
@@ -177,35 +177,35 @@
     // syz_x is length in bytes
     c3_d syz_x = len_x * pow(2, bloq-3);
 
-    // x_bytes is the data array (w/o leading 0x1)
-    c3_y* x_bytes = (c3_y*)u3a_malloc(syz_x*sizeof(c3_y));
-    u3r_bytes(0, syz_x, x_bytes, x_data);
+    // x_bytes is the data array (w/ leading 0x1, skipped by ?axpy; holds result)
+    c3_y* x_bytes = (c3_y*)u3a_malloc((syz_x+1)*sizeof(c3_y));
+    u3r_bytes(0, syz_x+1, x_bytes, x_data);
 
-    // y_bytes is the data array (w/ leading 0x1, skipped by ?axpy)
-    c3_y* y_bytes = (c3_y*)u3a_malloc((syz_x+1)*sizeof(c3_y));
-    u3r_bytes(0, syz_x+1, y_bytes, y_data);
-    
-    //  Switch on the block size.
+    // y_bytes is the data array (w/o leading 0x1)
+    c3_y* y_bytes = (c3_y*)u3a_malloc(syz_x*sizeof(c3_y));
+    u3r_bytes(0, syz_x, y_bytes, y_data);
+
+    //  Switch on the block size.  Computes x_bytes := -1*y + x = x - y.
     switch (u3x_atom(bloq)) {
       case 4:
-        haxpy(len_x, (float16_t){SB_REAL16_NEGONE}, (float16_t*)x_bytes, 1, (float16_t*)y_bytes, 1);
+        haxpy(len_x, (float16_t){SB_REAL16_NEGONE}, (float16_t*)y_bytes, 1, (float16_t*)x_bytes, 1);
         break;
 
       case 5:
-        saxpy(len_x, (float32_t){SB_REAL32_NEGONE}, (float32_t*)x_bytes, 1, (float32_t*)y_bytes, 1);
+        saxpy(len_x, (float32_t){SB_REAL32_NEGONE}, (float32_t*)y_bytes, 1, (float32_t*)x_bytes, 1);
         break;
 
       case 6:
-        daxpy(len_x, (float64_t){SB_REAL64_NEGONE}, (float64_t*)x_bytes, 1, (float64_t*)y_bytes, 1);
+        daxpy(len_x, (float64_t){SB_REAL64_NEGONE}, (float64_t*)y_bytes, 1, (float64_t*)x_bytes, 1);
         break;
 
       case 7:
-        qaxpy(len_x, (float128_t){SB_REAL128L_NEGONE,SB_REAL128U_NEGONE}, (float128_t*)x_bytes, 1, (float128_t*)y_bytes, 1);
+        qaxpy(len_x, (float128_t){SB_REAL128L_NEGONE,SB_REAL128U_NEGONE}, (float128_t*)y_bytes, 1, (float128_t*)x_bytes, 1);
         break;
     }
 
     // r_data is the result noun of [data]
-    u3_noun r_data = u3i_bytes((syz_x+1)*sizeof(c3_y), y_bytes);
+    u3_noun r_data = u3i_bytes((syz_x+1)*sizeof(c3_y), x_bytes);
 
     //  Clean up and return.
     u3a_free(x_bytes);


### PR DESCRIPTION
## Summary

`sub:la x y` silently returned an input instead of the difference. The `?axpy`-based `sub` jets computed `x - y` into one buffer but returned the other.

- **lagoon/vere & vere64**: PR #20 corrected the `?axpy` argument order (so `x - y` lands in `x_bytes`) but the function still returned `y_bytes` — the unmodified `y`.
- **maroon**: never swapped — computed `y - x` and returned that.

All three jets now allocate `x_bytes` as the pinned output buffer and `y_bytes` as the plain input, run `axpy(-1, y, x)` ⇒ `x := -1*y + x = x - y`, and return `x_bytes`.

## Why it slipped through

Every existing `sub` test used the symmetric case `1 - 1 = 0`, which passes under *all* failure modes (`x`, `y`, `x-y`, and `y-x` all equal `0` when `x = y = 1`).

## Tests

Added asymmetric regression tests `x=[5,2] - y=[3,1] = [2,1]` across every precision variant (lagoon bloq 4/5/6/7, maroon 4/5/6). These distinguish the correct result `[2,1]` from each failure mode: returning `y` → `[3,1]`, returning `x` → `[5,2]`, computing `y-x` → `[-2,-1]`.

## Verification

A standalone arm64 SoftBLAS reproduction of the corrected wiring (`saxpy(-1, y, x)` → return `x`) prints `[2.0, 1.0]`, matching the test canon. Full end-to-end exercise against compiled jets in Vere is pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)