### PR TITLE
Free leaked _get_dims allocation in dot/diag/cumsum wrappers

### DIFF
--- a/lagoon/vere/noun/jets/i/lagoon.c
+++ b/lagoon/vere/noun/jets/i/lagoon.c
@@ -2053,7 +2053,9 @@
                      u3_noun bloq)
   {
     u3_noun d_data = u3qi_la_diag(x_data, shape, bloq);
-    c3_d len_x0 = _get_dims(shape)[0];
+    c3_d *dim_x = _get_dims(shape);
+    c3_d len_x0 = dim_x[0];
+    u3a_free(dim_x);
     u3_noun r_data = u3qi_la_dot_i754(d_data, d_data, u3nt(len_x0, 0x1, u3_nul), u3k(bloq));
     return r_data;
   }
@@ -3043,7 +3045,9 @@
             _set_rounding(rnd);
             u3_noun r_data = u3qi_la_dot_i754(x_data, y_data, x_shape, x_bloq);
             if (r_data == u3_none) { return u3_none; }
-            c3_d len_x0 = _get_dims(x_shape)[0];
+            c3_d *dim_x = _get_dims(x_shape);
+            c3_d len_x0 = dim_x[0];
+            u3a_free(dim_x);
             return u3nc(u3nq(u3nt(len_x0, 0x1, u3_nul), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
 
           default:
@@ -3237,7 +3241,9 @@
       } else {
         u3_noun r_data = u3qi_la_diag(x_data, x_shape, x_bloq);
         if (r_data == u3_none) { return u3_none; }
-        c3_d len_x0 = _get_dims(x_shape)[0];
+        c3_d *dim_x = _get_dims(x_shape);
+        c3_d len_x0 = dim_x[0];
+        u3a_free(dim_x);
         return u3nc(u3nq(u3nt(len_x0, 0x1, u3_nul), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
       }
     }

--- a/lagoon/vere64/noun/jets/lagoon.c
+++ b/lagoon/vere64/noun/jets/lagoon.c
@@ -2050,7 +2050,9 @@
                      u3_noun bloq)
   {
     u3_noun d_data = u3qi_la_diag(x_data, shape, bloq);
-    c3_d len_x0 = _get_dims(shape)[0];
+    c3_d *dim_x = _get_dims(shape);
+    c3_d len_x0 = dim_x[0];
+    u3a_free(dim_x);
     u3_noun r_data = u3qi_la_dot_i754(d_data, d_data, u3nt(len_x0, 0x1, u3_nul), u3k(bloq));
     return r_data;
   }
@@ -3035,7 +3037,9 @@
             _set_rounding(rnd);
             u3_noun r_data = u3qi_la_dot_i754(x_data, y_data, x_shape, x_bloq);
             if (r_data == u3_none) { return u3_none; }
-            c3_d len_x0 = _get_dims(x_shape)[0];
+            c3_d *dim_x = _get_dims(x_shape);
+            c3_d len_x0 = dim_x[0];
+            u3a_free(dim_x);
             return u3nc(u3nq(u3nt(len_x0, 0x1, u3_nul), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
 
           default:
@@ -3224,7 +3228,9 @@
       } else {
         u3_noun r_data = u3qi_la_diag(x_data, x_shape, x_bloq);
         if (r_data == u3_none) { return u3_none; }
-        c3_d len_x0 = _get_dims(x_shape)[0];
+        c3_d *dim_x = _get_dims(x_shape);
+        c3_d len_x0 = dim_x[0];
+        u3a_free(dim_x);
         return u3nc(u3nq(u3nt(len_x0, 0x1, u3_nul), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
       }
     }

--- a/maroon/vere/noun/jets/i/lagoon.c
+++ b/maroon/vere/noun/jets/i/lagoon.c
@@ -2024,7 +2024,9 @@
                      u3_noun bloq)
   {
     u3_noun d_data = u3qi_la_diag(x_data, shape, bloq);
-    c3_d len_x0 = _get_dims(shape)[0];
+    c3_d *dim_x = _get_dims(shape);
+    c3_d len_x0 = dim_x[0];
+    u3a_free(dim_x);
     u3_noun r_data = u3qi_la_dot_real(d_data, d_data, u3nt(len_x0, 0x1, u3_nul), u3k(bloq));
     return r_data;
   }
@@ -3089,7 +3091,9 @@
           case c3__real:
             _set_rounding(rnd);
             u3_noun r_data = u3qi_la_dot_real(x_data, y_data, x_shape, x_bloq);
-            c3_d len_x0 = _get_dims(x_shape)[0];
+            c3_d *dim_x = _get_dims(x_shape);
+            c3_d len_x0 = dim_x[0];
+            u3a_free(dim_x);
             return u3nc(u3nq(u3nt(len_x0, 0x1, u3_nul), u3k(x_bloq), u3k(x_kind), u3k(x_fxp)), r_data);
 
           default:
@@ -3268,7 +3272,9 @@
         return u3m_bail(c3__exit);
       } else {
         u3_noun r_data = u3qi_la_diag(x_data, x_shape, x_bloq);
-        c3_d len_x0 = _get_dims(x_shape)[0];
+        c3_d *dim_x = _get_dims(x_shape);
+        c3_d len_x0 = dim_x[0];
+        u3a_free(dim_x);
         return u3nc(u3nq(u3nt(len_x0, 0x1, u3_nul), u3k(x_bloq), u3k(x_kind), u3k(x_fxp)), r_data);
       }
     }


### PR DESCRIPTION
## Summary

`_get_dims` `u3a_malloc`s a `c3_d*` and returns it. Three call sites in each jet file used `_get_dims(shape)[0]` and discarded the returned pointer, leaking a buffer (sized to the array's rank) on **every** call to the affected wrappers (`dot`/`trace`, and the `cumsum`/`diag`-family wrappers). The two other call sites already capture and free the pointer.

## Fix

At each leaking site, capture the pointer, read `[0]`, then `u3a_free` it — across all three jet files:

- `lagoon/vere/noun/jets/i/lagoon.c`
- `lagoon/vere64/noun/jets/lagoon.c`
- `maroon/vere/noun/jets/i/lagoon.c`

Pure leak fix; no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)