### PR TITLE
Fix quad mod-scalar reciprocal constant (0.0 -> 1.0)

### DIFF
--- a/lagoon/desk/tests/lib/lagoon-double-args-elementwise.hoon
+++ b/lagoon/desk/tests/lib/lagoon-double-args-elementwise.hoon
@@ -5548,4 +5548,16 @@
   %+  is-equal
     canon-gth-3x3-6u
   assay-gth-3x3-6u
+::
+::  Regression test for the quad mod-scalar (mods) jet reciprocal constant.
+::  u3qi_la_mods_i754 case 7 computes 1/n as the reciprocal; a typo set the
+::  quad numerator to 0.0 instead of 1.0, so the jet returned x unchanged.
+::  a=[7 5], n=3 so a mod n = [1 2]; the bug would yield [7 5].
+++  test-mods-1x2-7r  ^-  tang
+  =/  input-mods-1x2-7r  (en-ray:la [meta=[shape=~[1 2] bloq=7 kind=%i754 tail=~] baum=~[~[.~~~7.0 .~~~5.0]]])
+  =/  canon-mods-1x2-7r  (en-ray:la [meta=[shape=~[1 2] bloq=7 kind=%i754 tail=~] baum=~[~[.~~~1.0 .~~~2.0]]])
+  =/  assay-mods-1x2-7r  (mod-scalar:la input-mods-1x2-7r .~~~3.0)
+  %+  is-equal
+    canon-mods-1x2-7r
+  assay-mods-1x2-7r
 --

--- a/lagoon/vere/noun/jets/i/lagoon.c
+++ b/lagoon/vere/noun/jets/i/lagoon.c
@@ -1664,7 +1664,7 @@
 
       case 7:
         u3r_bytes(0, 16, (c3_y*)&(n128.v[0]), n);
-        f128M_div(&((float128_t){SB_REAL128L_ONE,SB_REAL128U_ZERO}), &n128, &in128);
+        f128M_div(&((float128_t){SB_REAL128L_ONE,SB_REAL128U_ONE}), &n128, &in128);
 
         for (c3_d i = 0; i < len_x; i++) {
           float128_t x_val128 = ((float128_t*)x_bytes)[i];

--- a/lagoon/vere64/noun/jets/lagoon.c
+++ b/lagoon/vere64/noun/jets/lagoon.c
@@ -1661,7 +1661,7 @@
 
       case 7:
         u3r_bytes(0, 16, (c3_y*)&(n128.v[0]), n);
-        f128M_div(&((float128_t){SB_REAL128L_ONE,SB_REAL128U_ZERO}), &n128, &in128);
+        f128M_div(&((float128_t){SB_REAL128L_ONE,SB_REAL128U_ONE}), &n128, &in128);
 
         for (c3_d i = 0; i < len_x; i++) {
           float128_t x_val128 = ((float128_t*)x_bytes)[i];

--- a/maroon/vere/noun/jets/i/lagoon.c
+++ b/maroon/vere/noun/jets/i/lagoon.c
@@ -1634,7 +1634,7 @@
 
       case 7:
         u3r_bytes(0, 16, (c3_y*)&(n128.v[0]), n);
-        f128M_div(&((float128_t){SB_REAL128L_ONE,SB_REAL128U_ZERO}), &n128, &in128);
+        f128M_div(&((float128_t){SB_REAL128L_ONE,SB_REAL128U_ONE}), &n128, &in128);
 
         for (c3_d i = 0; i < len_x; i++) {
           float128_t x_val128 = ((float128_t*)x_bytes)[i];


### PR DESCRIPTION
## Summary

`u3qi_la_mods_i754` case 7 (quad precision) computes the reciprocal `1/n` and then multiplies through the array. The 128-bit numerator was written as `{SB_REAL128L_ONE, SB_REAL128U_ZERO}` — which is `0.0`, not `1.0` (`SB_REAL128U_*` is the **upper/exponent** word: `SB_REAL128U_ONE = 0x3fff000000000000`, `SB_REAL128U_ZERO = 0x0`).

So the reciprocal evaluated to `0`, and quad `mod-scalar` multiplied every element by zero and returned `x` unchanged.

- Other precisions (`%4/%5/%6`) were unaffected.
- The sibling `divs` reciprocal (~line 1564) already used the correct `{..._ONE, ..._ONE}` = `1.0`.

## Fix

Changed `SB_REAL128U_ZERO` → `SB_REAL128U_ONE` at the reciprocal site in all three jet files:

- `lagoon/vere/noun/jets/i/lagoon.c`
- `lagoon/vere64/noun/jets/lagoon.c`
- `maroon/vere/noun/jets/i/lagoon.c`

## Test

Added a quad `mod-scalar` regression test: `a=[7,5]`, `n=3` → `[1,2]`. The bug would return `[7,5]`. (Operands are positive, so it is independent of the separate truncation-vs-floor question in `mod`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)