### PR TITLE
Correct gte/lth/lte jet header comments

### DIFF
--- a/lagoon/vere/noun/jets/i/lagoon.c
+++ b/lagoon/vere/noun/jets/i/lagoon.c
@@ -1058,7 +1058,7 @@
     return r_data;
   }
 
-/* gte - x > y
+/* gte - x >= y
 */
   u3_noun
   u3qi_la_gte_i754(u3_noun x_data,
@@ -1131,7 +1131,7 @@
     return r_data;
   }
 
-/* lth - x > y
+/* lth - x < y
 */
   u3_noun
   u3qi_la_lth_i754(u3_noun x_data,
@@ -1204,7 +1204,7 @@
     return r_data;
   }
 
-/* lte - x > y
+/* lte - x <= y
 */
   u3_noun
   u3qi_la_lte_i754(u3_noun x_data,

--- a/lagoon/vere64/noun/jets/lagoon.c
+++ b/lagoon/vere64/noun/jets/lagoon.c
@@ -1055,7 +1055,7 @@
     return r_data;
   }
 
-/* gte - x > y
+/* gte - x >= y
 */
   u3_noun
   u3qi_la_gte_i754(u3_noun x_data,
@@ -1128,7 +1128,7 @@
     return r_data;
   }
 
-/* lth - x > y
+/* lth - x < y
 */
   u3_noun
   u3qi_la_lth_i754(u3_noun x_data,
@@ -1201,7 +1201,7 @@
     return r_data;
   }
 
-/* lte - x > y
+/* lte - x <= y
 */
   u3_noun
   u3qi_la_lte_i754(u3_noun x_data,

--- a/maroon/vere/noun/jets/i/lagoon.c
+++ b/maroon/vere/noun/jets/i/lagoon.c
@@ -1028,7 +1028,7 @@
     return r_data;
   }
 
-/* gte - x > y
+/* gte - x >= y
 */
   u3_noun
   u3qi_la_gte_real(u3_noun x_data,
@@ -1101,7 +1101,7 @@
     return r_data;
   }
 
-/* lth - x > y
+/* lth - x < y
 */
   u3_noun
   u3qi_la_lth_real(u3_noun x_data,
@@ -1174,7 +1174,7 @@
     return r_data;
   }
 
-/* lte - x > y
+/* lte - x <= y
 */
   u3_noun
   u3qi_la_lte_real(u3_noun x_data,


### PR DESCRIPTION
## Summary

The header comments for the `gte`, `lth`, and `lte` comparison jets were copy-pasted from `gth` and all read `x > y`. They now match the operators actually used (`f128M_ge`/`f128M_lt`/`f128M_le`):

- `gte` → `x >= y`
- `lth` → `x < y`
- `lte` → `x <= y`

Comment-only change across all three jet files (`lagoon/vere`, `lagoon/vere64`, `maroon/vere`). No behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)