### PR TITLE
Make mod jet round the quotient with the active rounding mode

### DIFF
--- a/lagoon/desk/tests/lib/lagoon-double-args-elementwise.hoon
+++ b/lagoon/desk/tests/lib/lagoon-double-args-elementwise.hoon
@@ -5560,4 +5560,17 @@
   %+  is-equal
     canon-mods-1x2-7r
   assay-mods-1x2-7r
+::
+::  Regression test: the mod jet must match the Hoon reference, which rounds
+::  the quotient with `toi` under the active rounding mode (default %n,
+::  round-nearest), not by truncation.  5 mod 3 = 5 - 3*round(5/3) =
+::  5 - 3*2 = -1.  The old jet hardcoded truncation and returned 2.
+++  test-mod-1x1-6r  ^-  tang
+  =/  input-mod-1x1-6r  (en-ray:la [meta=[shape=~[1 1] bloq=6 kind=%i754 tail=~] baum=~[~[.~5.0]]])
+  =/  jnput-mod-1x1-6r  (en-ray:la [meta=[shape=~[1 1] bloq=6 kind=%i754 tail=~] baum=~[~[.~3.0]]])
+  =/  canon-mod-1x1-6r  (en-ray:la [meta=[shape=~[1 1] bloq=6 kind=%i754 tail=~] baum=~[~[.~-1.0]]])
+  =/  assay-mod-1x1-6r  (mod:la input-mod-1x1-6r jnput-mod-1x1-6r)
+  %+  is-equal
+    canon-mod-1x1-6r
+  assay-mod-1x1-6r
 --

--- a/lagoon/vere/noun/jets/i/lagoon.c
+++ b/lagoon/vere/noun/jets/i/lagoon.c
@@ -417,12 +417,12 @@
           float16_t y_val16 = ((float16_t*)y_bytes)[i];
           // Perform division x/n
           float16_t div_result16 = f16_div(x_val16, y_val16);
-          // Compute floor of the division result
-          c3_ds floor_result16 = f16_to_i64(div_result16, softfloat_round_minMag, false);
-          float16_t floor_float16 = i64_to_f16(floor_result16);
-          // Multiply n by floor(x/n)
-          float16_t mult_result16 = f16_mul(y_val16, floor_float16);
-          // Compute remainder: x - n * floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round16 = f16_to_i64(div_result16, softfloat_roundingMode, false);
+          float16_t quot_round_f16 = i64_to_f16(quot_round16);
+          // Multiply n by round(x/n)
+          float16_t mult_result16 = f16_mul(y_val16, quot_round_f16);
+          // Compute remainder: x - n * round(x/n)
           ((float16_t*)y_bytes)[i] = f16_sub(x_val16, mult_result16);
         }
         break;
@@ -433,12 +433,12 @@
           float32_t y_val32 = ((float32_t*)y_bytes)[i];
           // Perform division x/n
           float32_t div_result32 = f32_div(x_val32, y_val32);
-          // Compute floor of the division result
-          c3_ds floor_result32 = f32_to_i64(div_result32, softfloat_round_minMag, false);
-          float32_t floor_float32 = i64_to_f32(floor_result32);
-          // Multiply n by floor(x/n)
-          float32_t mult_result32 = f32_mul(y_val32, floor_float32);
-          // Compute remainder: x - n * floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round32 = f32_to_i64(div_result32, softfloat_roundingMode, false);
+          float32_t quot_round_f32 = i64_to_f32(quot_round32);
+          // Multiply n by round(x/n)
+          float32_t mult_result32 = f32_mul(y_val32, quot_round_f32);
+          // Compute remainder: x - n * round(x/n)
           ((float32_t*)y_bytes)[i] = f32_sub(x_val32, mult_result32);
         }
         break;
@@ -449,12 +449,12 @@
           float64_t y_val64 = ((float64_t*)y_bytes)[i];
           // Perform division x/n
           float64_t div_result64 = f64_div(x_val64, y_val64);
-          // Compute floor of the division result
-          c3_ds floor_result64 = f64_to_i64(div_result64, softfloat_round_minMag, false);
-          float64_t floor_float64 = i64_to_f64(floor_result64);
-          // Multiply n by floor(x/n)
-          float64_t mult_result64 = f64_mul(y_val64, floor_float64);
-          // Compute remainder: x - n * floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round64 = f64_to_i64(div_result64, softfloat_roundingMode, false);
+          float64_t quot_round_f64 = i64_to_f64(quot_round64);
+          // Multiply n by round(x/n)
+          float64_t mult_result64 = f64_mul(y_val64, quot_round_f64);
+          // Compute remainder: x - n * round(x/n)
           ((float64_t*)y_bytes)[i] = f64_sub(x_val64, mult_result64);
         }
         break;
@@ -466,14 +466,14 @@
           // Perform division x/n
           float128_t div_result128;
           f128M_div((float128_t*)&x_val128, (float128_t*)&y_val128, (float128_t*)&div_result128);
-          // Compute floor of the division result
-          c3_ds floor_result128 = f128M_to_i64(&div_result128, softfloat_round_minMag, false);
-          float128_t floor_float128;
-          i64_to_f128M(floor_result128, &floor_float128);
-          // Multiply n by floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round128 = f128M_to_i64(&div_result128, softfloat_roundingMode, false);
+          float128_t quot_round_f128;
+          i64_to_f128M(quot_round128, &quot_round_f128);
+          // Multiply n by round(x/n)
           float128_t mult_result128;
-          f128M_mul(((float128_t*)&y_val128), ((float128_t*)&floor_float128), ((float128_t*)&mult_result128));
-          // Compute remainder: x - n * floor(x/n)
+          f128M_mul(((float128_t*)&y_val128), ((float128_t*)&quot_round_f128), ((float128_t*)&mult_result128));
+          // Compute remainder: x - n * round(x/n)
           f128M_sub(((float128_t*)&x_val128), ((float128_t*)&mult_result128), &(((float128_t*)y_bytes)[i]));
         }
         break;
@@ -1619,12 +1619,12 @@
           float16_t x_val16 = ((float16_t*)x_bytes)[i];
           // Perform division x/n
           float16_t div_result16 = f16_mul(in16, x_val16);
-          // Compute floor of the division result
-          c3_ds floor_result16 = f16_to_i64(div_result16, softfloat_round_minMag, false);
-          float16_t floor_float16 = i64_to_f16(floor_result16);
-          // Multiply n by floor(x/n)
-          float16_t mult_result16 = f16_mul(n16, floor_float16);
-          // Compute remainder: x - n * floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round16 = f16_to_i64(div_result16, softfloat_roundingMode, false);
+          float16_t quot_round_f16 = i64_to_f16(quot_round16);
+          // Multiply n by round(x/n)
+          float16_t mult_result16 = f16_mul(n16, quot_round_f16);
+          // Compute remainder: x - n * round(x/n)
           ((float16_t*)x_bytes)[i] = f16_sub(x_val16, mult_result16);
         }
         break;
@@ -1637,12 +1637,12 @@
           float32_t x_val32 = ((float32_t*)x_bytes)[i];
           // Perform division x/n
           float32_t div_result32 = f32_mul((float32_t)in32, (float32_t)x_val32);
-          // Compute floor of the division result
-          c3_ds floor_result32 = f32_to_i64(div_result32, softfloat_round_minMag, false);
-          float32_t floor_float32 = i64_to_f32(floor_result32);
-          // Multiply n by floor(x/n)
-          float32_t mult_result32 = f32_mul(n32, floor_float32);
-          // Compute remainder: x - n * floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round32 = f32_to_i64(div_result32, softfloat_roundingMode, false);
+          float32_t quot_round_f32 = i64_to_f32(quot_round32);
+          // Multiply n by round(x/n)
+          float32_t mult_result32 = f32_mul(n32, quot_round_f32);
+          // Compute remainder: x - n * round(x/n)
           ((float32_t*)x_bytes)[i] = f32_sub(x_val32, mult_result32);
         }
         break;
@@ -1655,12 +1655,12 @@
           float64_t x_val64 = ((float64_t*)x_bytes)[i];
           // Perform division x/n
           float64_t div_result64 = f64_mul(in64, x_val64);
-          // Compute floor of the division result
-          c3_ds floor_result64 = f64_to_i64(div_result64, softfloat_round_minMag, false);
-          float64_t floor_float64 = i64_to_f64(floor_result64);
-          // Multiply n by floor(x/n)
-          float64_t mult_result64 = f64_mul(n64, floor_float64);
-          // Compute remainder: x - n * floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round64 = f64_to_i64(div_result64, softfloat_roundingMode, false);
+          float64_t quot_round_f64 = i64_to_f64(quot_round64);
+          // Multiply n by round(x/n)
+          float64_t mult_result64 = f64_mul(n64, quot_round_f64);
+          // Compute remainder: x - n * round(x/n)
           ((float64_t*)x_bytes)[i] = f64_sub(x_val64, mult_result64);
         }
         break;
@@ -1674,14 +1674,14 @@
           // Perform division x/n
           float128_t div_result128;
           f128M_mul((float128_t*)&in128, (float128_t*)&x_val128, (float128_t*)&div_result128);
-          // Compute floor of the division result
-          c3_ds floor_result128 = f128M_to_i64(&div_result128, softfloat_round_minMag, false);
-          float128_t floor_float128;
-          i64_to_f128M(floor_result128, &floor_float128);
-          // Multiply n by floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round128 = f128M_to_i64(&div_result128, softfloat_roundingMode, false);
+          float128_t quot_round_f128;
+          i64_to_f128M(quot_round128, &quot_round_f128);
+          // Multiply n by round(x/n)
           float128_t mult_result128;
-          f128M_mul(((float128_t*)&n128), ((float128_t*)&floor_float128), ((float128_t*)&mult_result128));
-          // Compute remainder: x - n * floor(x/n)
+          f128M_mul(((float128_t*)&n128), ((float128_t*)&quot_round_f128), ((float128_t*)&mult_result128));
+          // Compute remainder: x - n * round(x/n)
           f128M_sub(((float128_t*)&x_val128), ((float128_t*)&mult_result128), &(((float128_t*)x_bytes)[i]));
         }
         break;

--- a/lagoon/vere64/noun/jets/lagoon.c
+++ b/lagoon/vere64/noun/jets/lagoon.c
@@ -414,12 +414,12 @@
           float16_t y_val16 = ((float16_t*)y_bytes)[i];
           // Perform division x/n
           float16_t div_result16 = f16_div(x_val16, y_val16);
-          // Compute floor of the division result
-          c3_ds floor_result16 = f16_to_i64(div_result16, softfloat_round_minMag, false);
-          float16_t floor_float16 = i64_to_f16(floor_result16);
-          // Multiply n by floor(x/n)
-          float16_t mult_result16 = f16_mul(y_val16, floor_float16);
-          // Compute remainder: x - n * floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round16 = f16_to_i64(div_result16, softfloat_roundingMode, false);
+          float16_t quot_round_f16 = i64_to_f16(quot_round16);
+          // Multiply n by round(x/n)
+          float16_t mult_result16 = f16_mul(y_val16, quot_round_f16);
+          // Compute remainder: x - n * round(x/n)
           ((float16_t*)y_bytes)[i] = f16_sub(x_val16, mult_result16);
         }
         break;
@@ -430,12 +430,12 @@
           float32_t y_val32 = ((float32_t*)y_bytes)[i];
           // Perform division x/n
           float32_t div_result32 = f32_div(x_val32, y_val32);
-          // Compute floor of the division result
-          c3_ds floor_result32 = f32_to_i64(div_result32, softfloat_round_minMag, false);
-          float32_t floor_float32 = i64_to_f32(floor_result32);
-          // Multiply n by floor(x/n)
-          float32_t mult_result32 = f32_mul(y_val32, floor_float32);
-          // Compute remainder: x - n * floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round32 = f32_to_i64(div_result32, softfloat_roundingMode, false);
+          float32_t quot_round_f32 = i64_to_f32(quot_round32);
+          // Multiply n by round(x/n)
+          float32_t mult_result32 = f32_mul(y_val32, quot_round_f32);
+          // Compute remainder: x - n * round(x/n)
           ((float32_t*)y_bytes)[i] = f32_sub(x_val32, mult_result32);
         }
         break;
@@ -446,12 +446,12 @@
           float64_t y_val64 = ((float64_t*)y_bytes)[i];
           // Perform division x/n
           float64_t div_result64 = f64_div(x_val64, y_val64);
-          // Compute floor of the division result
-          c3_ds floor_result64 = f64_to_i64(div_result64, softfloat_round_minMag, false);
-          float64_t floor_float64 = i64_to_f64(floor_result64);
-          // Multiply n by floor(x/n)
-          float64_t mult_result64 = f64_mul(y_val64, floor_float64);
-          // Compute remainder: x - n * floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round64 = f64_to_i64(div_result64, softfloat_roundingMode, false);
+          float64_t quot_round_f64 = i64_to_f64(quot_round64);
+          // Multiply n by round(x/n)
+          float64_t mult_result64 = f64_mul(y_val64, quot_round_f64);
+          // Compute remainder: x - n * round(x/n)
           ((float64_t*)y_bytes)[i] = f64_sub(x_val64, mult_result64);
         }
         break;
@@ -463,14 +463,14 @@
           // Perform division x/n
           float128_t div_result128;
           f128M_div((float128_t*)&x_val128, (float128_t*)&y_val128, (float128_t*)&div_result128);
-          // Compute floor of the division result
-          c3_ds floor_result128 = f128M_to_i64(&div_result128, softfloat_round_minMag, false);
-          float128_t floor_float128;
-          i64_to_f128M(floor_result128, &floor_float128);
-          // Multiply n by floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round128 = f128M_to_i64(&div_result128, softfloat_roundingMode, false);
+          float128_t quot_round_f128;
+          i64_to_f128M(quot_round128, &quot_round_f128);
+          // Multiply n by round(x/n)
           float128_t mult_result128;
-          f128M_mul(((float128_t*)&y_val128), ((float128_t*)&floor_float128), ((float128_t*)&mult_result128));
-          // Compute remainder: x - n * floor(x/n)
+          f128M_mul(((float128_t*)&y_val128), ((float128_t*)&quot_round_f128), ((float128_t*)&mult_result128));
+          // Compute remainder: x - n * round(x/n)
           f128M_sub(((float128_t*)&x_val128), ((float128_t*)&mult_result128), &(((float128_t*)y_bytes)[i]));
         }
         break;
@@ -1616,12 +1616,12 @@
           float16_t x_val16 = ((float16_t*)x_bytes)[i];
           // Perform division x/n
           float16_t div_result16 = f16_mul(in16, x_val16);
-          // Compute floor of the division result
-          c3_ds floor_result16 = f16_to_i64(div_result16, softfloat_round_minMag, false);
-          float16_t floor_float16 = i64_to_f16(floor_result16);
-          // Multiply n by floor(x/n)
-          float16_t mult_result16 = f16_mul(n16, floor_float16);
-          // Compute remainder: x - n * floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round16 = f16_to_i64(div_result16, softfloat_roundingMode, false);
+          float16_t quot_round_f16 = i64_to_f16(quot_round16);
+          // Multiply n by round(x/n)
+          float16_t mult_result16 = f16_mul(n16, quot_round_f16);
+          // Compute remainder: x - n * round(x/n)
           ((float16_t*)x_bytes)[i] = f16_sub(x_val16, mult_result16);
         }
         break;
@@ -1634,12 +1634,12 @@
           float32_t x_val32 = ((float32_t*)x_bytes)[i];
           // Perform division x/n
           float32_t div_result32 = f32_mul(in32, x_val32);
-          // Compute floor of the division result
-          c3_ds floor_result32 = f32_to_i64(div_result32, softfloat_round_minMag, false);
-          float32_t floor_float32 = i64_to_f32(floor_result32);
-          // Multiply n by floor(x/n)
-          float32_t mult_result32 = f32_mul(n32, floor_float32);
-          // Compute remainder: x - n * floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round32 = f32_to_i64(div_result32, softfloat_roundingMode, false);
+          float32_t quot_round_f32 = i64_to_f32(quot_round32);
+          // Multiply n by round(x/n)
+          float32_t mult_result32 = f32_mul(n32, quot_round_f32);
+          // Compute remainder: x - n * round(x/n)
           ((float32_t*)x_bytes)[i] = f32_sub(x_val32, mult_result32);
         }
         break;
@@ -1652,12 +1652,12 @@
           float64_t x_val64 = ((float64_t*)x_bytes)[i];
           // Perform division x/n
           float64_t div_result64 = f64_mul(in64, x_val64);
-          // Compute floor of the division result
-          c3_ds floor_result64 = f64_to_i64(div_result64, softfloat_round_minMag, false);
-          float64_t floor_float64 = i64_to_f64(floor_result64);
-          // Multiply n by floor(x/n)
-          float64_t mult_result64 = f64_mul(n64, floor_float64);
-          // Compute remainder: x - n * floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round64 = f64_to_i64(div_result64, softfloat_roundingMode, false);
+          float64_t quot_round_f64 = i64_to_f64(quot_round64);
+          // Multiply n by round(x/n)
+          float64_t mult_result64 = f64_mul(n64, quot_round_f64);
+          // Compute remainder: x - n * round(x/n)
           ((float64_t*)x_bytes)[i] = f64_sub(x_val64, mult_result64);
         }
         break;
@@ -1671,14 +1671,14 @@
           // Perform division x/n
           float128_t div_result128;
           f128M_mul((float128_t*)&in128, (float128_t*)&x_val128, (float128_t*)&div_result128);
-          // Compute floor of the division result
-          c3_ds floor_result128 = f128M_to_i64(&div_result128, softfloat_round_minMag, false);
-          float128_t floor_float128;
-          i64_to_f128M(floor_result128, &floor_float128);
-          // Multiply n by floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round128 = f128M_to_i64(&div_result128, softfloat_roundingMode, false);
+          float128_t quot_round_f128;
+          i64_to_f128M(quot_round128, &quot_round_f128);
+          // Multiply n by round(x/n)
           float128_t mult_result128;
-          f128M_mul(((float128_t*)&n128), ((float128_t*)&floor_float128), ((float128_t*)&mult_result128));
-          // Compute remainder: x - n * floor(x/n)
+          f128M_mul(((float128_t*)&n128), ((float128_t*)&quot_round_f128), ((float128_t*)&mult_result128));
+          // Compute remainder: x - n * round(x/n)
           f128M_sub(((float128_t*)&x_val128), ((float128_t*)&mult_result128), &(((float128_t*)x_bytes)[i]));
         }
         break;

--- a/maroon/vere/noun/jets/i/lagoon.c
+++ b/maroon/vere/noun/jets/i/lagoon.c
@@ -387,12 +387,12 @@
           float16_t y_val16 = ((float16_t*)y_bytes)[i];
           // Perform division x/n
           float16_t div_result16 = f16_div(x_val16, y_val16);
-          // Compute floor of the division result
-          c3_ds floor_result16 = f16_to_i64(div_result16, softfloat_round_minMag, false);
-          float16_t floor_float16 = i64_to_f16(floor_result16);
-          // Multiply n by floor(x/n)
-          float16_t mult_result16 = f16_mul(y_val16, floor_float16);
-          // Compute remainder: x - n * floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round16 = f16_to_i64(div_result16, softfloat_roundingMode, false);
+          float16_t quot_round_f16 = i64_to_f16(quot_round16);
+          // Multiply n by round(x/n)
+          float16_t mult_result16 = f16_mul(y_val16, quot_round_f16);
+          // Compute remainder: x - n * round(x/n)
           ((float16_t*)y_bytes)[i] = f16_sub(x_val16, mult_result16);
         }
         break;
@@ -403,12 +403,12 @@
           float32_t y_val32 = ((float32_t*)y_bytes)[i];
           // Perform division x/n
           float32_t div_result32 = f32_div(x_val32, y_val32);
-          // Compute floor of the division result
-          c3_ds floor_result32 = f32_to_i64(div_result32, softfloat_round_minMag, false);
-          float32_t floor_float32 = i64_to_f32(floor_result32);
-          // Multiply n by floor(x/n)
-          float32_t mult_result32 = f32_mul(y_val32, floor_float32);
-          // Compute remainder: x - n * floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round32 = f32_to_i64(div_result32, softfloat_roundingMode, false);
+          float32_t quot_round_f32 = i64_to_f32(quot_round32);
+          // Multiply n by round(x/n)
+          float32_t mult_result32 = f32_mul(y_val32, quot_round_f32);
+          // Compute remainder: x - n * round(x/n)
           ((float32_t*)y_bytes)[i] = f32_sub(x_val32, mult_result32);
         }
         break;
@@ -419,12 +419,12 @@
           float64_t y_val64 = ((float64_t*)y_bytes)[i];
           // Perform division x/n
           float64_t div_result64 = f64_div(x_val64, y_val64);
-          // Compute floor of the division result
-          c3_ds floor_result64 = f64_to_i64(div_result64, softfloat_round_minMag, false);
-          float64_t floor_float64 = i64_to_f64(floor_result64);
-          // Multiply n by floor(x/n)
-          float64_t mult_result64 = f64_mul(y_val64, floor_float64);
-          // Compute remainder: x - n * floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round64 = f64_to_i64(div_result64, softfloat_roundingMode, false);
+          float64_t quot_round_f64 = i64_to_f64(quot_round64);
+          // Multiply n by round(x/n)
+          float64_t mult_result64 = f64_mul(y_val64, quot_round_f64);
+          // Compute remainder: x - n * round(x/n)
           ((float64_t*)y_bytes)[i] = f64_sub(x_val64, mult_result64);
         }
         break;
@@ -436,14 +436,14 @@
           // Perform division x/n
           float128_t div_result128;
           f128M_div((float128_t*)&x_val128, (float128_t*)&y_val128, (float128_t*)&div_result128);
-          // Compute floor of the division result
-          c3_ds floor_result128 = f128M_to_i64(&div_result128, softfloat_round_minMag, false);
-          float128_t floor_float128;
-          i64_to_f128M(floor_result128, &floor_float128);
-          // Multiply n by floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round128 = f128M_to_i64(&div_result128, softfloat_roundingMode, false);
+          float128_t quot_round_f128;
+          i64_to_f128M(quot_round128, &quot_round_f128);
+          // Multiply n by round(x/n)
           float128_t mult_result128;
-          f128M_mul(((float128_t*)&y_val128), ((float128_t*)&floor_float128), ((float128_t*)&mult_result128));
-          // Compute remainder: x - n * floor(x/n)
+          f128M_mul(((float128_t*)&y_val128), ((float128_t*)&quot_round_f128), ((float128_t*)&mult_result128));
+          // Compute remainder: x - n * round(x/n)
           f128M_sub(((float128_t*)&x_val128), ((float128_t*)&mult_result128), &(((float128_t*)y_bytes)[i]));
         }
         break;
@@ -1589,12 +1589,12 @@
           float16_t x_val16 = ((float16_t*)x_bytes)[i];
           // Perform division x/n
           float16_t div_result16 = f16_mul(in16, x_val16);
-          // Compute floor of the division result
-          c3_ds floor_result16 = f16_to_i64(div_result16, softfloat_round_minMag, false);
-          float16_t floor_float16 = i64_to_f16(floor_result16);
-          // Multiply n by floor(x/n)
-          float16_t mult_result16 = f16_mul(n16, floor_float16);
-          // Compute remainder: x - n * floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round16 = f16_to_i64(div_result16, softfloat_roundingMode, false);
+          float16_t quot_round_f16 = i64_to_f16(quot_round16);
+          // Multiply n by round(x/n)
+          float16_t mult_result16 = f16_mul(n16, quot_round_f16);
+          // Compute remainder: x - n * round(x/n)
           ((float16_t*)x_bytes)[i] = f16_sub(x_val16, mult_result16);
         }
         break;
@@ -1607,12 +1607,12 @@
           float32_t x_val32 = ((float32_t*)x_bytes)[i];
           // Perform division x/n
           float32_t div_result32 = f32_mul((float32_t)in32, (float32_t)x_val32);
-          // Compute floor of the division result
-          c3_ds floor_result32 = f32_to_i64(div_result32, softfloat_round_minMag, false);
-          float32_t floor_float32 = i64_to_f32(floor_result32);
-          // Multiply n by floor(x/n)
-          float32_t mult_result32 = f32_mul(n32, floor_float32);
-          // Compute remainder: x - n * floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round32 = f32_to_i64(div_result32, softfloat_roundingMode, false);
+          float32_t quot_round_f32 = i64_to_f32(quot_round32);
+          // Multiply n by round(x/n)
+          float32_t mult_result32 = f32_mul(n32, quot_round_f32);
+          // Compute remainder: x - n * round(x/n)
           ((float32_t*)x_bytes)[i] = f32_sub(x_val32, mult_result32);
         }
         break;
@@ -1625,12 +1625,12 @@
           float64_t x_val64 = ((float64_t*)x_bytes)[i];
           // Perform division x/n
           float64_t div_result64 = f64_mul(in64, x_val64);
-          // Compute floor of the division result
-          c3_ds floor_result64 = f64_to_i64(div_result64, softfloat_round_minMag, false);
-          float64_t floor_float64 = i64_to_f64(floor_result64);
-          // Multiply n by floor(x/n)
-          float64_t mult_result64 = f64_mul(n64, floor_float64);
-          // Compute remainder: x - n * floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round64 = f64_to_i64(div_result64, softfloat_roundingMode, false);
+          float64_t quot_round_f64 = i64_to_f64(quot_round64);
+          // Multiply n by round(x/n)
+          float64_t mult_result64 = f64_mul(n64, quot_round_f64);
+          // Compute remainder: x - n * round(x/n)
           ((float64_t*)x_bytes)[i] = f64_sub(x_val64, mult_result64);
         }
         break;
@@ -1644,14 +1644,14 @@
           // Perform division x/n
           float128_t div_result128;
           f128M_mul((float128_t*)&in128, (float128_t*)&x_val128, (float128_t*)&div_result128);
-          // Compute floor of the division result
-          c3_ds floor_result128 = f128M_to_i64(&div_result128, softfloat_round_minMag, false);
-          float128_t floor_float128;
-          i64_to_f128M(floor_result128, &floor_float128);
-          // Multiply n by floor(x/n)
+          // Round the quotient using the active rounding mode (matches Hoon toi)
+          c3_ds quot_round128 = f128M_to_i64(&div_result128, softfloat_roundingMode, false);
+          float128_t quot_round_f128;
+          i64_to_f128M(quot_round128, &quot_round_f128);
+          // Multiply n by round(x/n)
           float128_t mult_result128;
-          f128M_mul(((float128_t*)&n128), ((float128_t*)&floor_float128), ((float128_t*)&mult_result128));
-          // Compute remainder: x - n * floor(x/n)
+          f128M_mul(((float128_t*)&n128), ((float128_t*)&quot_round_f128), ((float128_t*)&mult_result128));
+          // Compute remainder: x - n * round(x/n)
           f128M_sub(((float128_t*)&x_val128), ((float128_t*)&mult_result128), &(((float128_t*)x_bytes)[i]));
         }
         break;


### PR DESCRIPTION
## Summary

The `mod`/`mods` jets reduced `x/n` to an integer with a hardcoded `softfloat_round_minMag` (truncation toward zero), but the Hoon reference rounds that quotient with `toi` under the **active rounding mode** (`fun-scalar %mod`, e.g. lagoon.hoon:1061). The two disagree for any mode other than `%z`, and even under the default `%n` for negative quotients — e.g. `5 mod 3 = 5 - 3·round(5/3) = -1` under round-nearest, vs `2` under truncation.

Per maintainer direction the jet should match Hoon (SoftBLAS is being aligned upstream similarly).

## Fix

Use `softfloat_roundingMode` — already established by `_set_rounding(rnd)` in both the `u3wi_la_mod` and `u3wi_la_mods` wrappers — for the quotient round in `u3qi_la_mod_i754` and `u3qi_la_mods_i754` (all four precisions), across all three jet files. The 8 mod/mods sites per file are changed; the range/linspace `ceil`-count sites stay on `minMag` (unrelated). The now-misnamed `floor_result`/`floor_float` locals are renamed to `quot_round`/`quot_round_f`, and the "floor" comments corrected.

## Test

Added a `mod` regression test: `5 mod 3 = -1` under the default `%n` mode (the old truncating jet returned `2`).

## Note

This is a behavioral change to `mod` for non-`%z` modes and negatives. It aligns the jet with the Hoon reference; reviewers fixing SoftBLAS upstream should confirm the upstream `mod` matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)