### PR TITLE
Fix any/all reductions for the numeric boolean convention

### DIFF
--- a/lagoon/desk/lib/lagoon.hoon
+++ b/lagoon/desk/lib/lagoon.hoon
@@ -994,15 +994,23 @@
     =/  rtol  (fill meta.a data:(scale meta.a +.tol))
     (lte (abs (sub a b)) (add atol (mul rtol (abs b))))
   ::
+  ::  Booleans use the numeric convention true=1, false=0 (see fun-scalar).
+  ::  An element is truthy iff its encoded value is nonzero (also +0.0=0x0).
+  ::  any: some element truthy  <=>  the max element is nonzero.
+  ::  all: every element truthy  <=>  the min element is nonzero.
+  ::  min/max reduce to an all-1s-shape scalar ray, so index with a
+  ::  rank-matched zero index rather than assuming a fixed dimensionality.
   ++  any
     |=  [a=ray]
     ^-  ?(%.y %.n)
-    (^lth (get-item (cumsum a) ~[0]) (roll shape.meta.a ^mul))
+    =/  dex  (reap (lent shape.meta.a) 0)
+    !(=((get-item (max a) dex) 0))
   ::
   ++  all
     |=  [a=ray]
     ^-  ?(%.y %.n)
-    =((get-item (cumsum a) ~[0]) 0)
+    =/  dex  (reap (lent shape.meta.a) 0)
+    !(=((get-item (min a) dex) 0))
   ::
   +$  ops   $?  %add
                 %sub

--- a/lagoon/desk/tests/lib/lagoon-array-utils.hoon
+++ b/lagoon/desk/tests/lib/lagoon-array-utils.hoon
@@ -208,6 +208,21 @@
       !>((get-item:la (max:la a) ~[0 0]))
       !>((snag (argmax:la a) (ravel:la a)))
   ==
+::
+::  any/all over boolean rays (numeric convention: true=1.0, false=0.0).
+::  any = some element truthy; all = every element truthy.
+++  test-any-all  ^-  tang
+  =/  all-true   (en-ray:la [meta=[shape=~[1 3] bloq=5 kind=%i754 tail=~] baum=~[~[.1.0 .1.0 .1.0]]])
+  =/  has-false  (en-ray:la [meta=[shape=~[1 3] bloq=5 kind=%i754 tail=~] baum=~[~[.1.0 .0.0 .1.0]]])
+  =/  all-false  (en-ray:la [meta=[shape=~[1 3] bloq=5 kind=%i754 tail=~] baum=~[~[.0.0 .0.0 .0.0]]])
+  ;:  weld
+    %+  expect-eq  !>(%.y)  !>((all:la all-true))
+    %+  expect-eq  !>(%.y)  !>((any:la all-true))
+    %+  expect-eq  !>(%.n)  !>((all:la has-false))
+    %+  expect-eq  !>(%.y)  !>((any:la has-false))
+    %+  expect-eq  !>(%.n)  !>((all:la all-false))
+    %+  expect-eq  !>(%.n)  !>((any:la all-false))
+  ==
 
 --
 :: to-tank


### PR DESCRIPTION
## Summary

A gnome investigation established that comparison ops across the library **consistently** encode booleans as numeric `true=1`, `false=0`:
- float arms store `1.0`/`0.0` (lagoon.hoon:1048–1095),
- uint arms use `!(^op b c)` which — since Hoon's `%.y`=0 — yields `true→1`, `false→0` (lagoon.hoon:1029–1032),
- the C jets use `? REAL_ONE : REAL_ZERO`, and the saloon docs / tinygrad consumer agree.

So there is **no convention clash** (correcting an earlier hypothesis). The only broken code was `any`/`all` (lagoon.hoon:994, 999), written for the opposite `true=0` assumption: `any` tested `cumsum < count` and `all` tested `cumsum == 0` — both inverted for every boolean ray. (The gnome's first-pass `=(sum,count)` idea is also unusable: it would compare a *float bit-pattern* sum to an integer count.)

## Fix

Reformulate in terms of `min`/`max`, which reduce correctly across kinds (they compare encoded values directly and seed at the first element):
- `any` = the **max** element is nonzero (some element truthy)
- `all` = the **min** element is nonzero (every element truthy)

The `!= 0` test is encoding-agnostic — both integer `0` and float `+0.0` are `0x0`. The scalar result is indexed with a rank-matched zero index (`(reap (lent shape) 0)`) instead of a hardcoded `~[0]`, so it works for arrays of any dimensionality (the old `~[0]` only worked for vectors).

## Impact

These arms were unreachable from any test (the `is-close` helper that calls `all` is defined but never invoked), and `saloon`'s `all-close`/`any-close` delegate here — so they were broken too, and are now fixed. Added a direct `any`/`all` test over all-true / mixed / all-false rays.

`lagoon-old.hoon` has the same bug but is a dead legacy file (slated for removal) and is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)