### PR TITLE
Guard range/linspace against degenerate counts

### DIFF
--- a/lagoon/vere/noun/jets/i/lagoon.c
+++ b/lagoon/vere/noun/jets/i/lagoon.c
@@ -1870,6 +1870,11 @@
       return u3_none;
     }
 
+    //  Guard degenerate count: n = 0 underflows n-1 and writes out of bounds.
+    if (n < 1) {
+      return u3_none;
+    }
+
     u3_noun r_data;
 
     switch (u3x_atom(bloq)) {
@@ -1974,7 +1979,9 @@
         u3r_bytes(0, 2, (c3_y*)&(a16.v), a);
         u3r_bytes(0, 2, (c3_y*)&(b16.v), b);
         u3r_bytes(0, 2, (c3_y*)&(interval16.v), d);
-        c3_d n16 = f16_to_i64(f16_ceil(f16_div(f16_sub(b16, a16), interval16)), softfloat_round_minMag, false);
+        c3_ds raw_n16 = f16_to_i64(f16_ceil(f16_div(f16_sub(b16, a16), interval16)), softfloat_round_minMag, false);
+        if ( raw_n16 < 1 || raw_n16 > 0xffffffff ) { return u3_none; }
+        c3_d n16 = raw_n16;
         c3_y* x_bytes16 = (c3_y*)u3a_malloc(((n16+1)*2)*sizeof(c3_y));
         ((float16_t*)x_bytes16)[0] = a16;
         for (c3_d i = 1; i < n16; i++) {
@@ -1990,7 +1997,9 @@
         u3r_bytes(0, 4, (c3_y*)&(a32.v), a);
         u3r_bytes(0, 4, (c3_y*)&(b32.v), b);
         u3r_bytes(0, 4, (c3_y*)&(interval32.v), d);
-        c3_d n32 = f32_to_i64(f32_ceil(f32_div(f32_sub(b32, a32), interval32)), softfloat_round_minMag, false);
+        c3_ds raw_n32 = f32_to_i64(f32_ceil(f32_div(f32_sub(b32, a32), interval32)), softfloat_round_minMag, false);
+        if ( raw_n32 < 1 || raw_n32 > 0xffffffff ) { return u3_none; }
+        c3_d n32 = raw_n32;
         c3_y* x_bytes32 = (c3_y*)u3a_malloc(((n32+1)*4)*sizeof(c3_y));
         ((float32_t*)x_bytes32)[0] = a32;
         for (c3_d i = 1; i < n32; i++) {
@@ -2006,7 +2015,9 @@
         u3r_bytes(0, 8, (c3_y*)&(a64.v), a);
         u3r_bytes(0, 8, (c3_y*)&(b64.v), b);
         u3r_bytes(0, 8, (c3_y*)&(interval64.v), d);
-        c3_d n64 = f64_to_i64(f64_ceil(f64_div(f64_sub(b64, a64), interval64)), softfloat_round_minMag, false);
+        c3_ds raw_n64 = f64_to_i64(f64_ceil(f64_div(f64_sub(b64, a64), interval64)), softfloat_round_minMag, false);
+        if ( raw_n64 < 1 || raw_n64 > 0xffffffff ) { return u3_none; }
+        c3_d n64 = raw_n64;
         c3_y* x_bytes64 = (c3_y*)u3a_malloc(((n64+1)*8)*sizeof(c3_y));
         ((float64_t*)x_bytes64)[0] = a64;
         for (c3_d i = 1; i < n64; i++) {
@@ -2026,7 +2037,9 @@
         f128M_sub(&b128, &a128, &tmp);
         f128M_div(&tmp, &interval128, &tmp);
         f128M_ceil(&tmp, &tmp);
-        c3_d n128 = f128M_to_i64(&tmp, softfloat_round_minMag, false);
+        c3_ds raw_n128 = f128M_to_i64(&tmp, softfloat_round_minMag, false);
+        if ( raw_n128 < 1 || raw_n128 > 0xffffffff ) { return u3_none; }
+        c3_d n128 = raw_n128;
         c3_y* x_bytes128 = (c3_y*)u3a_malloc(((n128+1)*16)*sizeof(c3_y));
         float128_t i128;
         ((float128_t*)x_bytes128)[0] = a128;

--- a/lagoon/vere64/noun/jets/lagoon.c
+++ b/lagoon/vere64/noun/jets/lagoon.c
@@ -1867,6 +1867,11 @@
       return u3_none;
     }
 
+    //  Guard degenerate count: n = 0 underflows n-1 and writes out of bounds.
+    if (n < 1) {
+      return u3_none;
+    }
+
     u3_noun r_data;
 
     switch (u3x_atom(bloq)) {
@@ -1971,7 +1976,9 @@
         u3r_bytes(0, 2, (c3_y*)&(a16.v), a);
         u3r_bytes(0, 2, (c3_y*)&(b16.v), b);
         u3r_bytes(0, 2, (c3_y*)&(interval16.v), d);
-        c3_d n16 = f16_to_i64(f16_ceil(f16_div(f16_sub(b16, a16), interval16)), softfloat_round_minMag, false);
+        c3_ds raw_n16 = f16_to_i64(f16_ceil(f16_div(f16_sub(b16, a16), interval16)), softfloat_round_minMag, false);
+        if ( raw_n16 < 1 || raw_n16 > 0xffffffff ) { return u3_none; }
+        c3_d n16 = raw_n16;
         c3_y* x_bytes16 = (c3_y*)u3a_malloc(((n16+1)*2)*sizeof(c3_y));
         ((float16_t*)x_bytes16)[0] = a16;
         for (c3_d i = 1; i < n16; i++) {
@@ -1987,7 +1994,9 @@
         u3r_bytes(0, 4, (c3_y*)&(a32.v), a);
         u3r_bytes(0, 4, (c3_y*)&(b32.v), b);
         u3r_bytes(0, 4, (c3_y*)&(interval32.v), d);
-        c3_d n32 = f32_to_i64(f32_ceil(f32_div(f32_sub(b32, a32), interval32)), softfloat_round_minMag, false);
+        c3_ds raw_n32 = f32_to_i64(f32_ceil(f32_div(f32_sub(b32, a32), interval32)), softfloat_round_minMag, false);
+        if ( raw_n32 < 1 || raw_n32 > 0xffffffff ) { return u3_none; }
+        c3_d n32 = raw_n32;
         c3_y* x_bytes32 = (c3_y*)u3a_malloc(((n32+1)*4)*sizeof(c3_y));
         ((float32_t*)x_bytes32)[0] = a32;
         for (c3_d i = 1; i < n32; i++) {
@@ -2003,7 +2012,9 @@
         u3r_bytes(0, 8, (c3_y*)&(a64.v), a);
         u3r_bytes(0, 8, (c3_y*)&(b64.v), b);
         u3r_bytes(0, 8, (c3_y*)&(interval64.v), d);
-        c3_d n64 = f64_to_i64(f64_ceil(f64_div(f64_sub(b64, a64), interval64)), softfloat_round_minMag, false);
+        c3_ds raw_n64 = f64_to_i64(f64_ceil(f64_div(f64_sub(b64, a64), interval64)), softfloat_round_minMag, false);
+        if ( raw_n64 < 1 || raw_n64 > 0xffffffff ) { return u3_none; }
+        c3_d n64 = raw_n64;
         c3_y* x_bytes64 = (c3_y*)u3a_malloc(((n64+1)*8)*sizeof(c3_y));
         ((float64_t*)x_bytes64)[0] = a64;
         for (c3_d i = 1; i < n64; i++) {
@@ -2023,7 +2034,9 @@
         f128M_sub(&b128, &a128, &tmp);
         f128M_div(&tmp, &interval128, &tmp);
         f128M_ceil(&tmp, &tmp);
-        c3_d n128 = f128M_to_i64(&tmp, softfloat_round_minMag, false);
+        c3_ds raw_n128 = f128M_to_i64(&tmp, softfloat_round_minMag, false);
+        if ( raw_n128 < 1 || raw_n128 > 0xffffffff ) { return u3_none; }
+        c3_d n128 = raw_n128;
         c3_y* x_bytes128 = (c3_y*)u3a_malloc(((n128+1)*16)*sizeof(c3_y));
         float128_t i128;
         ((float128_t*)x_bytes128)[0] = a128;

--- a/maroon/vere/noun/jets/i/lagoon.c
+++ b/maroon/vere/noun/jets/i/lagoon.c
@@ -1840,6 +1840,11 @@
       return u3_none;
     }
 
+    //  Guard degenerate count: n = 0 underflows n-1 and writes out of bounds.
+    if (n < 1) {
+      return u3_none;
+    }
+
     u3_noun r_data;
 
     switch (u3x_atom(bloq)) {
@@ -1943,7 +1948,9 @@
         u3r_bytes(0, 2, (c3_y*)&(a16.v), a);
         u3r_bytes(0, 2, (c3_y*)&(b16.v), b);
         u3r_bytes(0, 2, (c3_y*)&(interval16.v), d);
-        c3_d n16 = f16_to_i64(f16_div(f16_sub(b16, a16), interval16), softfloat_round_minMag, false);
+        c3_ds raw_n16 = f16_to_i64(f16_div(f16_sub(b16, a16), interval16), softfloat_round_minMag, false);
+        if ( raw_n16 < 1 || raw_n16 > 0xffffffff ) { return u3_none; }
+        c3_d n16 = raw_n16;
         c3_y* x_bytes16 = (c3_y*)u3a_malloc(((n16+1)*2+1)*sizeof(c3_y));
         for (c3_d i = 1; i <= n16; i++) {
           ((float16_t*)x_bytes16)[n16-i] = f16_add(a16, f16_mul(i32_to_f16(i), interval16));
@@ -1960,7 +1967,9 @@
         u3r_bytes(0, 4, (c3_y*)&(a32.v), a);
         u3r_bytes(0, 4, (c3_y*)&(b32.v), b);
         u3r_bytes(0, 4, (c3_y*)&(interval32.v), d);
-        c3_d n32 = f32_to_i64(f32_div(f32_sub(b32, a32), interval32), softfloat_round_minMag, false);
+        c3_ds raw_n32 = f32_to_i64(f32_div(f32_sub(b32, a32), interval32), softfloat_round_minMag, false);
+        if ( raw_n32 < 1 || raw_n32 > 0xffffffff ) { return u3_none; }
+        c3_d n32 = raw_n32;
         c3_y* x_bytes32 = (c3_y*)u3a_malloc(((n32+1)*4+1)*sizeof(c3_y));
         for (c3_d i = 1; i <= n32; i++) {
           ((float32_t*)x_bytes32)[n32-i] = f32_add(a32, f32_mul(i32_to_f32(i), interval32));
@@ -1977,7 +1986,9 @@
         u3r_bytes(0, 8, (c3_y*)&(a64.v), a);
         u3r_bytes(0, 8, (c3_y*)&(b64.v), b);
         u3r_bytes(0, 8, (c3_y*)&(interval64.v), d);
-        c3_d n64 = f64_to_i64(f64_div(f64_sub(b64, a64), interval64), softfloat_round_minMag, false);
+        c3_ds raw_n64 = f64_to_i64(f64_div(f64_sub(b64, a64), interval64), softfloat_round_minMag, false);
+        if ( raw_n64 < 1 || raw_n64 > 0xffffffff ) { return u3_none; }
+        c3_d n64 = raw_n64;
         c3_y* x_bytes64 = (c3_y*)u3a_malloc(((n64+1)*8+1)*sizeof(c3_y));
         for (c3_d i = 1; i < n64; i++) {
           ((float64_t*)x_bytes64)[n64-i] = f64_add(a64, f64_mul(i32_to_f64(i), interval64));
@@ -1997,7 +2008,9 @@
         float128_t tmp;
         f128M_sub(&b128, &a128, &tmp);
         f128M_div(&tmp, &interval128, &interval128);
-        c3_d n128 = f128M_to_i64(&tmp, softfloat_round_minMag, false);
+        c3_ds raw_n128 = f128M_to_i64(&tmp, softfloat_round_minMag, false);
+        if ( raw_n128 < 1 || raw_n128 > 0xffffffff ) { return u3_none; }
+        c3_d n128 = raw_n128;
         c3_y* x_bytes128 = (c3_y*)u3a_malloc(((n128+1)*16+1)*sizeof(c3_y));
         float128_t i128;
         for (c3_d i = 1; i < n128; i++) {


### PR DESCRIPTION
## Summary

`range` computed its element count as `n = f*_to_i64(ceil((b - a) / step))` with no validation:

- a **zero or NaN step** makes the quotient `Inf`/`NaN`, which `f*_to_i64` maps to `INT64_MAX`;
- a **descending pair** (`b < a`) makes it negative.

The count was stored **unsigned**, so `u3a_malloc((n + 1) * width)` either wrapped to a tiny/zero size or attempted an absurd allocation, and the fill loop then wrote out of bounds.

`linspace` separately dereferenced `x_bytes[n-1]` and looped on `n-1`; with `n = 0` the unsigned `n-1` underflows and writes out of bounds.

## Fix

- **range**: capture the count as signed and require `1 <= n <= 0xffffffff` before allocating; otherwise `return u3_none` and defer to the Hoon implementation. The upper bound catches the `INT64_MAX`/NaN cases and keeps the byte-size arithmetic from overflowing. (The wrapper that recomputes the count for the shape noun runs only after the qi function succeeds, so it needs no separate guard.)
- **linspace**: guard `n < 1` at entry and defer to Hoon (which handles `n = 1` itself).

Applied across all three jet files (`lagoon/vere`, `lagoon/vere64`, `maroon/vere`).

## Note

Degenerate inputs (e.g. `step = 0`) have no defined Hoon semantics either — the Hoon `range` would loop unboundedly — so this is a memory-safety guard, not a behavioral spec. The `0xffffffff` element cap is generous for realistic in-memory arrays; reviewers may tune it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)