### PR TITLE
Document the rounding-mode %a asymmetry

### DIFF
--- a/lagoon/desk/lib/lagoon.hoon
+++ b/lagoon/desk/lib/lagoon.hoon
@@ -8,6 +8,12 @@
 ::
 ::    rnd: rounding mode
 ::
+::  Limited to the four modes the hoon @rs/@rd/@rq/@rh precision doors
+::  accept: %n (nearest, ties to even), %u (toward +inf), %d (toward
+::  -inf), %z (toward zero).  The underlying ++fl engine — and the C
+::  jets' _set_rounding — also implement %a (nearest, ties away from
+::  zero), but the precision doors do not expose it, so %a is
+::  intentionally excluded here; the jets handle it defensively only.
 +$  rounding-mode  ?(%n %u %d %z)
 ++  lake
   |=  [inrnd=rounding-mode]

--- a/lagoon/vere/noun/jets/i/lagoon.c
+++ b/lagoon/vere/noun/jets/i/lagoon.c
@@ -35,7 +35,10 @@
     c3_d c[2];
   };
 
-  //  $?(%n %u %d %z %a)
+  //  Set the SoftFloat/SoftBLAS rounding mode from a rounding-mode atom.
+  //  Accepts %n %u %d %z (see +$rounding-mode); %a (nearest, ties away)
+  //  is handled too, but the hoon @rs/@rd/@rq/@rh doors never produce it.
+  //  Any other value bails.
   static inline void
   _set_rounding(c3_w a)
   {

--- a/lagoon/vere64/noun/jets/lagoon.c
+++ b/lagoon/vere64/noun/jets/lagoon.c
@@ -37,7 +37,10 @@
     c3_d c[2];
   };
 
-  //  $?(%n %u %d %z %a)
+  //  Set the SoftFloat/SoftBLAS rounding mode from a rounding-mode atom.
+  //  Accepts %n %u %d %z (see +$rounding-mode); %a (nearest, ties away)
+  //  is handled too, but the hoon @rs/@rd/@rq/@rh doors never produce it.
+  //  Any other value bails.
   static inline void
   _set_rounding(c3_y a)
   {

--- a/maroon/vere/noun/jets/i/lagoon.c
+++ b/maroon/vere/noun/jets/i/lagoon.c
@@ -30,7 +30,10 @@
     c3_d c[2];
   };
 
-  //  $?(%n %u %d %z %a)
+  //  Set the SoftFloat/SoftBLAS rounding mode from a rounding-mode atom.
+  //  Accepts %n %u %d %z (see +$rounding-mode); %a (nearest, ties away)
+  //  is handled too, but the hoon @rs/@rd/@rq/@rh doors never produce it.
+  //  Any other value bails.
   static inline void
   _set_rounding(c3_w a)
   {


### PR DESCRIPTION
## Summary

The C jets' `_set_rounding` handles **five** rounding modes (`%n %u %d %z %a`), but lagoon's `+$rounding-mode` exposes only **four** (`%n %u %d %z`). The audit flagged this as an undocumented asymmetry.

## Investigation

Tracing the float cores in the vendored `hoon.hoon`:
- `++fl` (the arbitrary-precision engine) and the C `_set_rounding` both implement `%a` — round to nearest, **ties away from zero**.
- but the `@rs`/`@rd`/`@rq`/`@rh` precision **doors** that lagoon actually calls (`~(add rs rnd)`, etc.) each have sample `r=$?(%n %u %d %z)` — only four modes.

So `%a` is **unreachable through the standard float API**. Adding it to `+$rounding-mode` would make `~(add rs rnd)` fail to typecheck (a 5-mode `rnd` doesn't nest into the door's 4-mode sample) and break the Hoon fallback. The four-mode type is therefore *correct*; the gap is purely documentation.

## Fix (docs only)

- Annotate `+$rounding-mode` (lagoon.hoon) with the four supported modes and why `%a` is excluded (the precision doors don't expose it, though `++fl` and the jets implement it).
- Replace the bare `// $?(%n %u %d %z %a)` comment over each jet's `_set_rounding` (all three jet files) with an explanation that `%a` is handled defensively but never produced by the hoon doors, and unknown values bail.

No behavioral change.

## If you'd rather

The alternative is to *remove* the `%a` case from the C `_set_rounding` so the jet's domain exactly matches the 4-mode reference (the `default` bail would then catch any stray `%a`). I kept it as forward-compatible defensive code and documented instead, but happy to switch to removal if you prefer the tighter match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)