### PR TITLE
Add el-wise-op order regression tests

### DIFF
--- a/lagoon/desk/tests/lib/lagoon-single-args.hoon
+++ b/lagoon/desk/tests/lib/lagoon-single-args.hoon
@@ -2691,4 +2691,29 @@
       !>((range:la meta-1x5-7 [.~~~5 .~~~-0.1] .~~~-0.5))
   ==
 
+::  el-wise-op must preserve element order.  It previously flopped the
+::  raveled list ("compensate for LSB"), which reversed every Hoon-only
+::  transcendental (exp/sin/cos/tan/abs) for n>1 elements.  Identity on
+::  [1 2 3 4] must return [1 2 3 4], not [4 3 2 1].
+++  test-el-wise-op-order-5r  ^-  tang
+  =/  meta-1x4-5  [~[4] 5 %i754 ~]
+  =/  input-1x4-5  (en-ray:la [meta-1x4-5 ~[.1.0 .2.0 .3.0 .4.0]])
+  ;:  weld
+    %+  expect-eq
+      !>(input-1x4-5)
+      !>((el-wise-op:la input-1x4-5 |=(e=@ e)))
+  ==
+
+::  abs flows through el-wise-op; distinct magnitudes and mixed signs make
+::  any order reversal visible in the public single-arg path.
+++  test-abs-1x4-5r  ^-  tang
+  =/  meta-1x4-5  [~[4] 5 %i754 ~]
+  =/  input-1x4-5  (en-ray:la [meta-1x4-5 ~[.-1.0 .2.0 .-3.0 .4.0]])
+  =/  canon-1x4-5  (en-ray:la [meta-1x4-5 ~[.1.0 .2.0 .3.0 .4.0]])
+  ;:  weld
+    %+  expect-eq
+      !>(canon-1x4-5)
+      !>((abs:la input-1x4-5))
+  ==
+
 --


### PR DESCRIPTION
## Summary

PR #21 fixed `el-wise-op`, which had `flop`ped the raveled element list ("compensate for LSB") and so **reversed every Hoon-only transcendental** (`exp`/`sin`/`cos`/`tan`/`abs`) for arrays with more than one element. That fix shipped without a regression test in the suite — it was validated with a throwaway generator — so the bug could silently come back.

## Tests (added to `lagoon-single-args`)

- **`test-el-wise-op-order-5r`** — identity through `el-wise-op` on `[1 2 3 4]` must return `[1 2 3 4]`, not `[4 3 2 1]`. This is the purest order check: the identity gate has no jet, so it exercises the Hoon `el-wise-op` directly with nothing to mask a reversal.
- **`test-abs-1x4-5r`** — `abs` of `[-1 2 -3 4]` must return `[1 2 3 4]`. Distinct magnitudes and mixed signs make any reversal visible through the public single-arg path.

Both fail against the pre-#21 `flop` and pass against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)