### PR TITLE
Fix any/all negation syntax (! -> ?!)

### DIFF
--- a/lagoon/desk/lib/lagoon.hoon
+++ b/lagoon/desk/lib/lagoon.hoon
@@ -1004,13 +1004,13 @@
     |=  [a=ray]
     ^-  ?(%.y %.n)
     =/  dex  (reap (lent shape.meta.a) 0)
-    !(=((get-item (max a) dex) 0))
+    ?!(=((get-item (max a) dex) 0))
   ::
   ++  all
     |=  [a=ray]
     ^-  ?(%.y %.n)
     =/  dex  (reap (lent shape.meta.a) 0)
-    !(=((get-item (min a) dex) 0))
+    ?!(=((get-item (min a) dex) 0))
   ::
   +$  ops   $?  %add
                 %sub


### PR DESCRIPTION
## Summary

The `any`/`all` rewrite in #28 used `!(=(...))` for logical negation. The bare `!` irregular does **not** parse in that position — Hoon requires `?!(=(...))`. As merged, `lib/lagoon.hoon` **fails to build**.

Caught while validating on a live ship (~nec):
- `!(=(3 0))` → build-failed
- `?!(=(3 0))` → build succeeded

## Fix

Change the two negations in `any`/`all` from `!(=(...))` to `?!(=(...))`. No logic change — the min/max-based reductions are unchanged.

## Note

This is a hotfix for `main` (which currently won't compile `lib/lagoon`). Recommend merging promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)