### PR TITLE
Make any/all rank-agnostic via the reduced ray's ravel head

### DIFF
--- a/lagoon/desk/lib/lagoon.hoon
+++ b/lagoon/desk/lib/lagoon.hoon
@@ -998,19 +998,17 @@
   ::  An element is truthy iff its encoded value is nonzero (also +0.0=0x0).
   ::  any: some element truthy  <=>  the max element is nonzero.
   ::  all: every element truthy  <=>  the min element is nonzero.
-  ::  min/max reduce to an all-1s-shape scalar ray, so index with a
-  ::  rank-matched zero index rather than assuming a fixed dimensionality.
+  ::  Read the reduced scalar as the head of its ravel, so this is
+  ::  independent of min/max's output shape and works for any rank.
   ++  any
     |=  [a=ray]
     ^-  ?(%.y %.n)
-    =/  dex  (reap (lent shape.meta.a) 0)
-    ?!(=((get-item (max a) dex) 0))
+    ?!(=(-:(ravel (max a)) 0))
   ::
   ++  all
     |=  [a=ray]
     ^-  ?(%.y %.n)
-    =/  dex  (reap (lent shape.meta.a) 0)
-    ?!(=((get-item (min a) dex) 0))
+    ?!(=(-:(ravel (min a)) 0))
   ::
   +$  ops   $?  %add
                 %sub

--- a/lagoon/desk/tests/lib/lagoon-array-utils.hoon
+++ b/lagoon/desk/tests/lib/lagoon-array-utils.hoon
@@ -223,6 +223,21 @@
     %+  expect-eq  !>(%.n)  !>((all:la all-false))
     %+  expect-eq  !>(%.n)  !>((any:la all-false))
   ==
+::
+::  1-D coverage: min/max reduce regardless of rank, so any/all must work
+::  on a plain vector too (the 2-D-only test above hid a rank assumption).
+++  test-any-all-1d  ^-  tang
+  =/  all-true   (en-ray:la [meta=[shape=~[3] bloq=5 kind=%i754 tail=~] baum=~[.1.0 .1.0 .1.0]])
+  =/  has-false  (en-ray:la [meta=[shape=~[3] bloq=5 kind=%i754 tail=~] baum=~[.1.0 .0.0 .1.0]])
+  =/  all-false  (en-ray:la [meta=[shape=~[3] bloq=5 kind=%i754 tail=~] baum=~[.0.0 .0.0 .0.0]])
+  ;:  weld
+    %+  expect-eq  !>(%.y)  !>((all:la all-true))
+    %+  expect-eq  !>(%.y)  !>((any:la all-true))
+    %+  expect-eq  !>(%.n)  !>((all:la has-false))
+    %+  expect-eq  !>(%.y)  !>((any:la has-false))
+    %+  expect-eq  !>(%.n)  !>((all:la all-false))
+    %+  expect-eq  !>(%.n)  !>((any:la all-false))
+  ==
 
 --
 :: to-tank


### PR DESCRIPTION
## Summary

Follow-up to #28/#33. The `any`/`all` reductions indexed `min`/`max`'s scalar result with a zero index sized to the **input** rank:

```hoon
?!(=((get-item (max a) (reap (lent shape.meta.a) 0)) 0))
```

That matches the **Hoon** `min`/`max` (which preserve rank via `scalar-to-ray`), but the `min`/`max` **jets** return a rank-2 scalar even for a 1-D input — so `any`/`all` **crash on a plain vector** under the jets. Verified on a live ship (~nec, old jets): a 1-D input bails in `get-item-number`, a 2-D input passes. The existing test was 2-D only, which is exactly what hid the assumption.

## Fix

Read the reduced scalar as the **head of its ravel**, which flattens the data directly and is independent of `min`/`max`'s output shape:

```hoon
++  any  |=(a=ray ?!(=(-:(ravel (max a)) 0)))
++  all  |=(a=ray ?!(=(-:(ravel (min a)) 0)))
```

Works for any rank; also drops the `reap`/`dex` plumbing.

## Validation

Ran on ~nec against base's `min`/`max`: the `-:(ravel ...)` form passes for **both 1-D and 2-D** all-true / mixed / all-false rays. Added a 1-D `any`/`all` test to the suite alongside the existing 2-D one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)