### PR TITLE
Fix two latent C bugs and add motes include in lagoon jet

### DIFF
--- a/lagoon/vere/noun/jets/i/lagoon.c
+++ b/lagoon/vere/noun/jets/i/lagoon.c
@@ -3,6 +3,8 @@
 #include "jets/q.h"
 #include "jets/w.h"
 
+#include "c3/motes.h"
+
 #include "noun.h"
 #include "softfloat.h"
 #include "softblas.h"
@@ -3206,6 +3208,7 @@
                 u3r_bytes(0, 8, (c3_y*)&d_, d);
                 n_ = f64_to_i64(f64_ceil(f64_div(f64_sub((float64_t){b_}, (float64_t){a_}), (float64_t){d_})), softfloat_round_minMag, false) - 1;
                 break;
+              }
               case 7: {
                 c3_d a__[2], b__[2], d__[2];
                 u3r_bytes(0, 16, (c3_y*)&a__, a);
@@ -3321,13 +3324,12 @@
     {
       u3m_bail(c3__exit);
     } else {
-      u3_noun x_shape, x_bloq, x_kind, x_tail,
+      u3_noun x_shape, x_bloq, x_kind,
               y_shape,
               rnd;
       x_shape = u3h(x_meta);          //  2
       x_bloq = u3h(u3t(x_meta));      //  6
       x_kind = u3h(u3t(u3t(x_meta))); // 14
-      x_tail = u3t(u3t(u3t(x_meta))); // 15
       y_shape = u3h(y_meta);          //  2
       rnd = u3h(u3t(u3t(u3t(cor))));  // 30
       if ( c3n == _check(u3nc(x_meta, x_data)) ||


### PR DESCRIPTION
## Summary

Three fixes to `lagoon/vere/noun/jets/i/lagoon.c`, all discovered when compiling the jet under vere's zig build (`-Wall -Werror`). The numerics mirror is never built as C, so the first two were latent here.

- **`u3wi_la_range` — missing brace.** `case 6` of `switch (x_bloq)` opened a `{` that was never closed before `case 7`, leaving the switch unbalanced. Under the compiler this cascaded into bogus "function definition is not allowed here" errors on every following function. Adds the missing `}`.
- **`u3wi_la_mmul` — `x_tail` set but unused.** `x_tail` was declared and assigned (copy-pasted from the `range` pattern) but never read — the mmul result already carries its meta. `-Werror` rejects it as set-but-unused. Removed.
- **Add `#include "c3/motes.h"`.** So the file resolves `c3__` motes under build systems that don't pull them in transitively (vere's zig build needs this).

## Testing

With these applied, vere builds cleanly with the up-to-date numerics lagoon jets (zig 0.15.2, native aarch64-macos). No behavioral change to any jet — these are a brace fix, a dead-variable removal, and an include.

🤖 Generated with [Claude Code](https://claude.com/claude-code)