### PR TITLE
Wire %int2 two's-complement integer arrays into Lagoon

### DIFF
--- a/lagoon/desk/lib/lagoon.hoon
+++ b/lagoon/desk/lib/lagoon.hoon
@@ -1,4 +1,5 @@
 /-  lagoon
+/+  twoc
 =+  lagoon
 ::                                                    ::
 ::::                    ++la                          ::  (2v) vector/matrix ops
@@ -57,7 +58,7 @@
       %ud
       ::
         %int2
-      !!
+      %sd
       ::
         %i754
       ?+    bloq.meta  ~|(bloq.meta !!)
@@ -448,7 +449,7 @@
     ?-    kind.meta
         %uint  `@`1
       ::
-        %int2  !!
+        %int2  `@`1
       ::
         %i754
       ?+  bloq.meta  ~|(bloq.meta !!)
@@ -472,7 +473,7 @@
       ?-    kind.meta
           %uint  `@`1
         ::
-          %int2  !!
+          %int2  `@`1
         ::
           %i754
         ?+  bloq.meta  !!
@@ -1046,7 +1047,23 @@
         %neq  |=([b=@ c=@] ?:(.=(b c) 0 1))
       ==
       ::
-        %int2  !!
+        %int2
+      ::  modular two's-complement (wraps on overflow), via /lib/twoc.
+      ::  comparisons return 1=true / 0=false as a value, matching %uint.
+      ?+  fun  !!
+        %add  ~(add twoc:twoc bloq)
+        %sub  ~(sub twoc:twoc bloq)
+        %mul  ~(mul twoc:twoc bloq)
+        %div  ~(div twoc:twoc bloq)
+        %mod  ~(rem twoc:twoc bloq)
+        %pow  ~(pow twoc:twoc bloq)
+        %gth  |=([b=@ c=@] ?:((~(gth twoc:twoc bloq) b c) 1 0))
+        %gte  |=([b=@ c=@] ?:((~(gte twoc:twoc bloq) b c) 1 0))
+        %lth  |=([b=@ c=@] ?:((~(lth twoc:twoc bloq) b c) 1 0))
+        %lte  |=([b=@ c=@] ?:((~(lte twoc:twoc bloq) b c) 1 0))
+        %equ  |=([b=@ c=@] ?:(.=(b c) 1 0))
+        %neq  |=([b=@ c=@] ?:(.=(b c) 0 1))
+      ==
       ::
         %i754
       ?+    `^bloq`bloq  !!
@@ -1113,12 +1130,15 @@
     |=  [=bloq =kind fun=ops]
     ^-  $-(@ @)
     ?-    kind
-        %uint  
+        %uint
       ?+  fun  !!
         %abs  |=(b=@ b)
       ==
       ::
-        %int2  !!
+        %int2
+      ?+  fun  !!
+        %abs  ~(abs twoc:twoc bloq)
+      ==
       ::
         %i754
       ?+    bloq  !!

--- a/lagoon/desk/tests/lib/lagoon-int2.hoon
+++ b/lagoon/desk/tests/lib/lagoon-int2.hoon
@@ -1,0 +1,57 @@
+/-  *lagoon
+/+  *test
+/+  *lagoon
+::::  /tests/lib/lagoon-int2 -- two's-complement signed integer arrays
+::
+::  int8 = bloq 3, kind %int2.  Build rays with `fill`, read back with
+::  get-item.  Verifies modular wrap, signed div/rem, abs, the 1=true/
+::  0=false comparison convention, and a reduction (cumsum).
+::
+^|
+|%
+::  apply a binary ray op to two int8 scalars, read the result scalar
+++  bin
+  |=  [op=$-([ray ray] ray) b=@ c=@]  ^-  @
+  =/  m1=meta  [~[1 1] 3 %int2 ~]
+  (get-item:la (op (fill:la m1 b) (fill:la m1 c)) ~[0 0])
+::
+::  arithmetic, modular two's-complement (int8)
+++  test-int2-arith  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x7)   !>((bin add:la 0x5 0x2))     ::  5+2=7
+    %+  expect-eq  !>(`@`0x96)  !>((bin add:la 0x64 0x32))   ::  100+50 wraps -> -106
+    %+  expect-eq  !>(`@`0xfb)  !>((bin sub:la 0x5 0xa))     ::  5-10=-5
+    %+  expect-eq  !>(`@`0xf6)  !>((bin mul:la 0xfb 0x2))    ::  -5*2=-10
+    %+  expect-eq  !>(`@`0xfd)  !>((bin div:la 0xf9 0x2))    ::  -7/2 trunc=-3
+    %+  expect-eq  !>(`@`0xff)  !>((bin mod:la 0xf9 0x2))    ::  -7%2=-1
+  ==
+::  comparisons return value 1 (true) / 0 (false), matching %uint/%i754
+++  test-int2-compare  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x1)  !>((bin lth:la 0xff 0x1))     ::  -1 < 1 -> 1
+    %+  expect-eq  !>(`@`0x0)  !>((bin gth:la 0xff 0x1))     ::  -1 > 1 -> 0
+    %+  expect-eq  !>(`@`0x1)  !>((bin gth:la 0x1 0xff))     ::  1 > -1 -> 1
+    %+  expect-eq  !>(`@`0x1)  !>((bin gte:la 0x5 0x5))      ::  5 >= 5 -> 1
+    %+  expect-eq  !>(`@`0x1)  !>((bin equ:la 0x5 0x5))      ::  5 == 5 -> 1
+    %+  expect-eq  !>(`@`0x0)  !>((bin equ:la 0x5 0x6))      ::  5 == 6 -> 0
+  ==
+::  unary abs over a filled ray
+++  test-int2-abs  ^-  tang
+  =/  m1=meta  [~[1 1] 3 %int2 ~]
+  ;:  weld
+    %+  expect-eq  !>(`@`0x5)  !>((get-item:la (abs:la (fill:la m1 0xfb)) ~[0 0]))
+    %+  expect-eq  !>(`@`0x5)  !>((get-item:la (abs:la (fill:la m1 0x5)) ~[0 0]))
+  ==
+::  ones builder uses the %int2 constant 1
+++  test-int2-ones  ^-  tang
+  =/  m=meta  [~[2 2] 3 %int2 ~]
+  %+  expect-eq  !>(`@`0x1)  !>((get-item:la (ones:la m) ~[0 0]))
+::  cumsum reduction over a 1x4 int2 ray [1 2 3 -1] = 5
+++  test-int2-cumsum  ^-  tang
+  =/  r=ray  (fill:la [~[1 4] 3 %int2 ~] 0x0)
+  =.  r  (set-item:la r ~[0 0] 0x1)
+  =.  r  (set-item:la r ~[0 1] 0x2)
+  =.  r  (set-item:la r ~[0 2] 0x3)
+  =.  r  (set-item:la r ~[0 3] 0xff)
+  %+  expect-eq  !>(`@`0x5)  !>((get-item:la (cumsum:la r) ~[0 0]))
+--

--- a/libmath/desk/lib/twoc.hoon
+++ b/libmath/desk/lib/twoc.hoon
@@ -29,11 +29,11 @@
     ^-  @
     ?>  (^lte `@`a (dec ~(out fe bloq)))
     %+  mix
-      (rsh 0 a) 
+      (rsh 0 a)
     (~(sum fe bloq) (not 0 len (dis a 1)) 1)
   ::
   :: 1001 is -7 in int4
-  :: 1111 - 1001 = 0110  
+  :: 1111 - 1001 = 0110
   :: 0110 + 0001 = 0111 (7)
   ++  twoc-to-s
     |=  a=@
@@ -51,8 +51,9 @@
   ::  and multiply serve signed and unsigned alike.
   ::
   ++  add  |=([a=@ b=@] ^-(@ (mod (^add a b) len-mod)))
-  ::  +neg: two's-complement negation, (~a + 1) mod 2^len.  neg(min) = min.
-  ++  neg  |=(a=@ ^-(@ (mod (^add (^sub (dec len-mod) (mod a len-mod)) 1) len-mod)))
+  ::  +neg: two's-complement negation, ~a + 1 (flip the len bits, add one),
+  ::  the standard XOR-then-increment.  neg(min) = min (wraps).
+  ++  neg  |=(a=@ ^-(@ (mod +((not 0 len (mod a len-mod))) len-mod)))
   ++  sub  |=([a=@ b=@] ^-(@ (add a (neg b))))
   ++  mul  |=([a=@ b=@] ^-(@ (mod (^mul (mod a len-mod) (mod b len-mod)) len-mod)))
   ::  +abs: |a| as a two's-complement value (abs(min) wraps back to min).
@@ -76,8 +77,8 @@
     =/  q   (^div (abs a) (abs b))
     ?:  =(sa sb)  (mod q len-mod)            :: same sign -> non-negative
     (neg q)                                  :: opposite sign -> negative
-  ::  +mod: signed remainder, sign follows the DIVIDEND (C `%` / truncated).
-  ::  a == (add (mul (div a b) b) (mod a b)).
+  ::  +rem: signed remainder, sign follows the DIVIDEND (C `%` / truncated).
+  ::  a == (add (mul (div a b) b) (rem a b)).
   ++  rem
     |=  [a=@ b=@]
     ^-  @

--- a/libmath/desk/lib/twoc.hoon
+++ b/libmath/desk/lib/twoc.hoon
@@ -27,7 +27,7 @@
   ++  s-to-twoc
     |=  a=@s
     ^-  @
-    ?>  (lte `@`a (dec ~(out fe bloq)))
+    ?>  (^lte `@`a (dec ~(out fe bloq)))
     %+  mix
       (rsh 0 a) 
     (~(sum fe bloq) (not 0 len (dis a 1)) 1)
@@ -39,38 +39,62 @@
     |=  a=@
     ^-  @s
     ?:  =(1 (msb a))
-      (new:si | +((sub (dec (bex len)) a)))
+      (new:si | +((^sub (dec (bex len)) a)))
     (new:si & a)
   ::
   ::
-  ++  add
-    |=  [a=@ b=@]
-    =/  res  (^add a b)
-    ?.  (^gth (xeb res) len)
-      res 
-    =/  rez=@  (rep 0 (snip (rip [0 1] res)))
-    ?:  !(overflow a b rez)
-      rez
-    ~|('signed int overflow' !!)
+  ::  Arithmetic is MODULAR two's-complement: results wrap mod 2^len rather
+  ::  than crashing on overflow.  This DIVERGES from a checked-overflow
+  ::  signed-integer type, but matches hardware two's-complement and the
+  ::  wrapping behavior of Lagoon's %uint (fe) scalars.  Because the low len
+  ::  bits of a sum/product are independent of sign, the same bit-level add
+  ::  and multiply serve signed and unsigned alike.
   ::
+  ++  add  |=([a=@ b=@] ^-(@ (mod (^add a b) len-mod)))
+  ::  +neg: two's-complement negation, (~a + 1) mod 2^len.  neg(min) = min.
+  ++  neg  |=(a=@ ^-(@ (mod (^add (^sub (dec len-mod) (mod a len-mod)) 1) len-mod)))
+  ++  sub  |=([a=@ b=@] ^-(@ (add a (neg b))))
+  ++  mul  |=([a=@ b=@] ^-(@ (mod (^mul (mod a len-mod) (mod b len-mod)) len-mod)))
+  ::  +abs: |a| as a two's-complement value (abs(min) wraps back to min).
+  ++  abs  |=(a=@ ^-(@ ?:(=(1 (msb a)) (neg a) (mod a len-mod))))
+  ::  +len-mod: 2^len, the modulus (len is the bit width = 2^bloq).
+  ++  len-mod  (bex len)
+  ::  +overflow: would a + b overflow a CHECKED signed add?  Retained for
+  ::  callers that want to detect, rather than wrap; +add no longer uses it.
   ++  overflow
     |=  [a=@ b=@ c=@]
     ?|  &(=(0 (msb c)) =(1 (msb a)) =(1 (msb b)))
         &(=(1 (msb c)) =(0 (msb a)) =(0 (msb b)))
     ==
-  ::
-  ++  mul
-  ::
-  :: https://stackoverflow.com/questions/20793701/how-to-do-two-complement-multiplication-and-division-of-integers
+  ::  +div: signed division, truncating toward zero (C / Hoon `div` style).
+  ::  Division by zero crashes (as `div` does).  div(min, -1) wraps to min.
+  ++  div
     |=  [a=@ b=@]
-    =/  ae  (rep bloq ~[a (extend a)])
-    =/  be  (rep bloq ~[b (extend b)])
-    =/  c  (cut 0 [0 (^mul 2 len)] (^mul ae be))
-    ?:  (lte (xeb c) len)
-      c
-    ?:  !=((dec (bex len)) (cut 0 [len len] c))
-      ~|('signed int overflow' !!)
-    (cut 0 [0 len] c)
+    ^-  @
+    =/  sa  (msb a)
+    =/  sb  (msb b)
+    =/  q   (^div (abs a) (abs b))
+    ?:  =(sa sb)  (mod q len-mod)            :: same sign -> non-negative
+    (neg q)                                  :: opposite sign -> negative
+  ::  +mod: signed remainder, sign follows the DIVIDEND (C `%` / truncated).
+  ::  a == (add (mul (div a b) b) (mod a b)).
+  ++  rem
+    |=  [a=@ b=@]
+    ^-  @
+    =/  r  (mod (abs a) (abs b))
+    ?:  =(0 (msb a))  (mod r len-mod)        :: dividend non-negative
+    (neg r)                                  :: dividend negative
+  ::  +pow: a to a NON-NEGATIVE integer power n (n a raw @, not two's-comp),
+  ::  by modular squaring.  pow(a, 0) = 1.
+  ++  pow
+    |=  [a=@ n=@]
+    ^-  @
+    =/  base  (mod a len-mod)
+    =/  acc   (mod 1 len-mod)
+    |-  ^-  @
+    ?:  =(0 n)  acc
+    =?  acc  =(1 (dis n 1))  (mul acc base)
+    $(n (rsh 0 n), base (mul base base))
   ::
   ::
   ++  extend

--- a/libmath/desk/tests/lib/twoc.hoon
+++ b/libmath/desk/tests/lib/twoc.hoon
@@ -1,0 +1,73 @@
+  ::  /tests/lib/twoc
+::::
+::    Two's-complement integer arithmetic (modular), int8 = bloq 3.
+::
+/+  *test,
+    twoc
+^|
+=/  t  ~(. twoc:twoc 3)
+|%
+++  test-add  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x96)  !>((add:t 0x64 0x32))   ::  100+50 wraps -> -106
+    %+  expect-eq  !>(`@`0x0)   !>((add:t 0xff 0x1))    ::  -1+1=0
+    %+  expect-eq  !>(`@`0x7)   !>((add:t 0x5 0x2))     ::  5+2=7
+  ==
+::
+++  test-neg-sub  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0xff)  !>((neg:t 0x1))         ::  -1
+    %+  expect-eq  !>(`@`0x80)  !>((neg:t 0x80))        ::  min negates to self
+    %+  expect-eq  !>(`@`0xfb)  !>((sub:t 0x5 0xa))     ::  5-10=-5
+    %+  expect-eq  !>(`@`0x0)   !>((sub:t 0x7 0x7))
+  ==
+::
+++  test-mul  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x1)   !>((mul:t 0xff 0xff))   ::  -1*-1=1
+    %+  expect-eq  !>(`@`0x0)   !>((mul:t 0x10 0x10))   ::  16*16=256 wraps 0
+    %+  expect-eq  !>(`@`0xf6)  !>((mul:t 0xfb 0x2))    ::  -5*2=-10
+  ==
+::
+++  test-abs  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x5)   !>((abs:t 0xfb))        ::  |-5|=5
+    %+  expect-eq  !>(`@`0x5)   !>((abs:t 0x5))
+    %+  expect-eq  !>(`@`0x80)  !>((abs:t 0x80))        ::  |min| wraps to min
+  ==
+::
+++  test-div-rem  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0xfd)  !>((div:t 0xf9 0x2))    ::  -7/2 trunc=-3
+    %+  expect-eq  !>(`@`0xfd)  !>((div:t 0x7 0xfe))    ::  7/-2 trunc=-3
+    %+  expect-eq  !>(`@`0x3)   !>((div:t 0xf9 0xfe))   ::  -7/-2=3
+    %+  expect-eq  !>(`@`0xff)  !>((rem:t 0xf9 0x2))    ::  -7%2=-1
+    %+  expect-eq  !>(`@`0x1)   !>((rem:t 0x7 0xfe))    ::  7%-2=1
+  ==
+::
+++  test-pow  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0xf8)  !>((pow:t 0xfe 3))      ::  -2^3=-8
+    %+  expect-eq  !>(`@`0x51)  !>((pow:t 0x3 4))       ::  3^4=81
+    %+  expect-eq  !>(`@`0x1)   !>((pow:t 0x5 0))       ::  x^0=1
+  ==
+::
+++  test-compare  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(%.n)  !>((gth:t 0xff 0x1))        ::  -1 > 1 ? no
+    %+  expect-eq  !>(%.y)  !>((lth:t 0xff 0x1))        ::  -1 < 1 ? yes
+    %+  expect-eq  !>(%.y)  !>((gth:t 0x1 0xff))        ::  1 > -1 ? yes
+    %+  expect-eq  !>(%.y)  !>((lte:t 0x5 0x5))         ::  5 <= 5
+    %+  expect-eq  !>(%.y)  !>((gte:t 0x5 0x5))         ::  5 >= 5
+    %+  expect-eq  !>(%.n)  !>((lth:t 0x5 0x5))         ::  5 < 5 ? no
+  ==
+::
+::  round-trip identity for the division algorithm: a == div*b + rem
+++  test-div-identity  ^-  tang
+  =/  pairs=(list [@ @])  ~[[0xf9 0x2] [0x7 0xfe] [0xf9 0xfe] [0x64 0x7] [0x9c 0x5]]
+  %+  roll  pairs
+  |=  [[a=@ b=@] acc=tang]
+  =/  recon  (add:t (mul:t (div:t a b) b) (rem:t a b))
+  %+  weld  acc
+  (expect-eq !>(a) !>(recon))
+--

--- a/libmath/desk/tests/lib/twoc.hoon
+++ b/libmath/desk/tests/lib/twoc.hoon
@@ -1,11 +1,17 @@
   ::  /tests/lib/twoc
 ::::
-::    Two's-complement integer arithmetic (modular), int8 = bloq 3.
+::    Two's-complement integer arithmetic (modular).  The bulk of the
+::    arithmetic is checked at int8 (bloq 3); the wrap boundaries and the
+::    len/len-mod modulus are re-checked at int16 (bloq 4), int32 (bloq 5),
+::    and int64 (bloq 6) so width handling is exercised at several sizes.
 ::
 /+  *test,
     twoc
 ^|
-=/  t  ~(. twoc:twoc 3)
+=/  t  ~(. twoc:twoc 3)            :: int8
+=/  t16  ~(. twoc:twoc 4)          :: int16
+=/  t32  ~(. twoc:twoc 5)          :: int32
+=/  t64  ~(. twoc:twoc 6)          :: int64
 |%
 ++  test-add  ^-  tang
   ;:  weld
@@ -20,6 +26,7 @@
     %+  expect-eq  !>(`@`0x80)  !>((neg:t 0x80))        ::  min negates to self
     %+  expect-eq  !>(`@`0xfb)  !>((sub:t 0x5 0xa))     ::  5-10=-5
     %+  expect-eq  !>(`@`0x0)   !>((sub:t 0x7 0x7))
+    %+  expect-eq  !>(`@`0x0)   !>((neg:t 0x0))         ::  -0=0
   ==
 ::
 ++  test-mul  ^-  tang
@@ -70,4 +77,37 @@
   =/  recon  (add:t (mul:t (div:t a b) b) (rem:t a b))
   %+  weld  acc
   (expect-eq !>(a) !>(recon))
+::
+::  int16 (bloq 4): wrap boundary at 0x7fff/0x8000, neg, signed mul/cmp
+++  test-int16  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x7d0)   !>((add:t16 0x3e8 0x3e8))    ::  1000+1000=2000
+    %+  expect-eq  !>(`@`0x8000)  !>((add:t16 0x7fff 0x1))     ::  maxint+1 -> min
+    %+  expect-eq  !>(`@`0xffff)  !>((neg:t16 0x1))            ::  -1
+    %+  expect-eq  !>(`@`0x8000)  !>((neg:t16 0x8000))         ::  min self
+    %+  expect-eq  !>(`@`0xfffe)  !>((mul:t16 0xffff 0x2))     ::  -1*2=-2
+    %+  expect-eq  !>(`@`0x1)     !>((mul:t16 0xffff 0xffff))  ::  -1*-1=1
+    %+  expect-eq  !>(%.y)        !>((lth:t16 0xffff 0x1))     ::  -1 < 1
+    %+  expect-eq  !>(`@`0x5)     !>((abs:t16 0xfffb))         ::  |-5|=5
+  ==
+::
+::  int32 (bloq 5): same boundary structure at 32 bits
+++  test-int32  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x8000.0000)  !>((add:t32 0x7fff.ffff 0x1))     ::  maxint+1 -> min
+    %+  expect-eq  !>(`@`0xffff.ffff)  !>((neg:t32 0x1))                 ::  -1
+    %+  expect-eq  !>(`@`0x1)          !>((mul:t32 0xffff.ffff 0xffff.ffff))  ::  -1*-1=1
+    %+  expect-eq  !>(`@`0xffff.fffe)  !>((mul:t32 0xffff.ffff 0x2))     ::  -1*2=-2
+    %+  expect-eq  !>(%.y)             !>((gth:t32 0x1 0xffff.ffff))     ::  1 > -1
+  ==
+::
+::  int64 (bloq 6): boundary structure at 64 bits
+++  test-int64  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x8000.0000.0000.0000)  !>((add:t64 0x7fff.ffff.ffff.ffff 0x1))  ::  maxint+1 -> min
+    %+  expect-eq  !>(`@`0xffff.ffff.ffff.ffff)  !>((neg:t64 0x1))                         ::  -1
+    %+  expect-eq  !>(`@`0x1)                    !>((mul:t64 0xffff.ffff.ffff.ffff 0xffff.ffff.ffff.ffff))  ::  -1*-1=1
+    %+  expect-eq  !>(`@`0xffff.ffff.ffff.fffe)  !>((mul:t64 0xffff.ffff.ffff.ffff 0x2))   ::  -1*2=-2
+    %+  expect-eq  !>(%.y)                       !>((lth:t64 0xffff.ffff.ffff.ffff 0x1))   ::  -1 < 1
+  ==
 --


### PR DESCRIPTION
Implements Lagoon's `%int2` array kind (two's-complement signed integers), previously declared but `!!` at every operation, by dispatching to an extended `/lib/twoc`.  Mirrors the existing `%uint` (fe) and `%i754` (rs/rd/rq/rh) branches.

## `/lib/twoc` — extended for the ops `fun-scalar` needs

- **Modular** `add`/`sub`/`neg`/`mul`: wrap mod `2^len` instead of crashing on overflow.  Documented as a deliberate **divergence** from a checked-overflow signed type — it matches hardware two's-complement and the wrapping of Lagoon's `%uint`.  (The old crash-on-overflow `add`/`mul` had no live callers: `lagoon-old.hoon`, their only consumer, was already deleted.)
- `+neg` uses the idiomatic **XOR-then-increment** (`not`+1), not a bignum subtract.
- New: `abs`, `div` (truncate toward zero, C-style), `rem` (sign follows the dividend), `pow` (modular squaring), `len-mod`.
- Internal plain `sub`/`lte` switched to `^sub`/`^lte` to avoid the new same-name door arms.

## `lagoon.hoon` — `%int2` wired at all 6 sites

- `/+ twoc` import; `get-term` → `%sd`; `eye`/`ones` constant `1`; `scale`/`en-ray` already handled.
- `fun-scalar`: `add/sub/mul/div/mod(=rem)/pow`, and `gth/gte/lth/lte/equ/neq` returning **1 = true / 0 = false** as a value, matching the `%uint`/`%i754` convention (careful with the loobean→value direction).
- `trans-scalar`: `%abs`.

## Tests (all pass on `~hex`)

- `/tests/lib/twoc`: int8 arithmetic + the `div*b+rem` identity, plus wrap-boundary/neg/mul/compare re-checked at **int16, int32, int64**.
- `/tests/lib/lagoon-int2`: end-to-end `%int2` ray arithmetic (incl. wrap), the 1/0 comparison convention, `abs`, `ones`, and a `cumsum` reduction.

Follow-up (not here): `%unum` (posit) array integration uses the same dispatch sites — see `libmath/NEXT-STEPS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)