### PR TITLE
Fix /lib/fixed signed mul/div/scale; deduplicate onto /lib/twoc

### DIFF
--- a/libmath/desk/lib/fixed.hoon
+++ b/libmath/desk/lib/fixed.hoon
@@ -1,128 +1,138 @@
-  ::  /lib/fixed
+/+  twoc
+::::  /lib/fixed -- fixed-point arithmetic
 ::::  Version ~2024.1.15 by ~lagrev-nocfep and ~mopfel-winrux
+::::  ~2026.6.1: rebuilt on /lib/twoc for correct signed mul/div/scale.
+::
+::  A fixed-point number is a two's-complement integer of N = a + b + 1 bits
+::  interpreted as value / 2^b:
+::
+::    value = 1/2^b * ( -2^(N-1) x_(N-1) + sum_{n=0}^{N-2} 2^n x_n )
+::
+::  where a = integer bits, b = fractional bits, and the leading bit is the
+::  sign.  (Yates2023, http://www.digitalsignallabs.com/downloads/fp.pdf)
+::
+::  Arithmetic is signed and MODULAR (wraps mod 2^N on overflow), delegating
+::  to the width-keyed +twid door of /lib/twoc so the sign handling is shared
+::  with the rest of numerics rather than reimplemented here.
 ::
 |%
-::
-::  \frac{1}{2^b}\left(-2^{N-1}x_{N-1}+\sum_{n=0}^{N-2} 2^n x_n \right)
-::
-::  where
-::    N = a + b + 1, 2^bloq size
-::    a = integer bits
-::    b = fractional bits
-::
-::  Yates2023 http://www.digitalsignallabs.com/downloads/fp.pdf
-::
 +$  prec  [a=@ b=@]   ::  fixed-point precision, a+b+1=bloq
+::  +wid: total bit width N = a + b + 1 of a precision.
+++  wid  |=(=prec ^-(@ :(^add a.prec b.prec 1)))
+::  +ng: the /lib/twoc width-keyed door at a given precision's N.
+++  ng   |=(=prec ~(. twid:twoc (wid prec)))
+::    +add: [@ prec @ prec] -> @
 ::
-::    +add: [@ [@ @] @ [@ @]] -> @
-::
-::  Add two fixed-point numbers.
+::  Add two fixed-point numbers of equal precision (signed, wrapping).
 ::    Examples
-::      > (add 0b100.0001.0000 [8 8] 0b101.0001.0000 [8 8])
-::      0b1000.0010.0000
-::
+::      > (add 0x180 [8 8] 0x240 [8 8])   :: 1.5 + 2.25
+::      0x3c0                             :: 3.75
 ::  Source
 ++  add
   |=  [x=@ xprec=prec y=@ yprec=prec]
   ?>  =(xprec yprec)
-  =/  sum  (^add x y)
-  =/  sump=prec  [+(a.xprec) b.xprec]
-  (lo sum sump :(^add a.xprec b.xprec 1))
-::    +sub: [@ [@ @] @ [@ @]] -> @
+  (add:(ng xprec) x y)
+::    +sub: [@ prec @ prec] -> @
 ::
-::  Subtract two fixed-point numbers.
+::  Subtract two fixed-point numbers of equal precision (signed, wrapping).
 ::    Examples
-::      > (sub 0b100.0001.0000 [8 8] 0b101.0001.0000 [8 8])
-::      0b1111.1111.0000.0000
-::      > (sub 0b101.0001.0000 [8 8] 0b100.0001.0000 [8 8])
-::      0b1.0000.0000
-::
+::      > (sub 0x100 [8 8] 0x200 [8 8])   :: 1.0 - 2.0
+::      0x1.ff00                          :: -1.0 in N=17 bits
 ::  Source
 ++  sub
   |=  [x=@ xprec=prec y=@ yprec=prec]
   ?>  =(xprec yprec)
-  =/  n  :(^add a.xprec b.xprec 1)
-  (end [4 1] (add x xprec (twoc y n) yprec))
-::    +mul: [@ [@ @] @ [@ @]] -> [@ [@ @]]
+  (sub:(ng xprec) x y)
+::    +mul: [@ prec @ prec] -> [@ prec]
 ::
-::  Multiply two fixed-point numbers.  Changes the resulting precision.
+::  Multiply two fixed-point numbers (signed).  The product precision widens:
+::  integer bits a.x + a.y + 1, fractional bits b.x + b.y.
 ::    Examples
-::      > (mul 0b100.0001.0000 [8 8] 0b101.0001.0000 [8 8])
-::      [0b1000.0100.0001.0000.0000 17 16]
-::
+::      > (mul 0x180 [8 8] 0x200 [8 8])   :: 1.5 * 2.0
+::      [0x3.0000 17 16]                  :: 3.0 in q17.16
+::      > (mul (neg 0x180 [8 8]) [8 8] 0x200 [8 8])   :: -1.5 * 2.0
+::      [0x3.fffd.0000 17 16]             :: -3.0
 ::  Source
 ++  mul
   |=  [x=@ xprec=prec y=@ yprec=prec]
-  =/  prod  (^mul x y)
+  ^-  [@ prec]
   =/  prodp=prec  [:(^add a.xprec a.yprec 1) (^add b.xprec b.yprec)]
-  [prod prodp]
-::    +div: [@ [@ @] @ [@ @]] -> [@ [@ @]]
+  ::  re-encode each operand at the product width, then signed multiply.
+  =/  px  (s-to-twoc:(ng prodp) (to-s x xprec))
+  =/  py  (s-to-twoc:(ng prodp) (to-s y yprec))
+  [(mul:(ng prodp) px py) prodp]
+::    +div: [@ prec @ prec] -> [@ prec]
 ::
-::  Divide two fixed-point numbers.  Keeps the initial precision.
+::  Divide two fixed-point numbers of equal precision (signed), keeping the
+::  input precision.  Division by zero crashes.
 ::    Examples
-::      > (div 0b100.0001.0000 [8 8] 0b101.0001.0000 [8 8])
-::      [0b1100.1101 8 8]
-::
-::  Reference:  https://webpages.charlotte.edu/~jmconrad/ECGR6185-2007-01/notes/UNCC-IESLecture23%20-%20Fixed%20Point%20Math.pdf
-::
+::      > (div (neg 0x300 [8 8]) [8 8] 0x200 [8 8])   :: -3.0 / 2.0
+::      [0x1.fe80 8 8]                                :: -1.5
 ::  Source
 ++  div
   |=  [x=@ xprec=prec y=@ yprec=prec]
+  ^-  [@ prec]
   ?>  ~|(%argument-precision-must-match =(xprec yprec))
-  =/  quot  (^div (lsh [0 b.xprec] x) y)
-  [quot xprec]
-::    +hi: [@ [@ @] @] -> @
+  ::  scale the dividend up by 2^b before the signed divide so the quotient
+  ::  lands back in xprec's fixed-point scale: (x * 2^b) / y.
+  =/  sx   (to-s x xprec)
+  =/  num  (new:si (syn:si sx) (lsh [0 b.xprec] (abs:si sx)))
+  =/  qa   (fra:si num (to-s y yprec))
+  [(s-to-twoc:(ng xprec) qa) xprec]
+::    +to-s: [@ prec] -> @s
 ::
-::  Extract the high bits of x.  (Wordlength HI)
+::  Decode a fixed-point bit pattern to a hoon signed integer (the stored
+::  two's-complement value, fractional bits included).
+::  Source
+++  to-s
+  |=  [x=@ =prec]
+  ^-  @s
+  (twoc-to-s:(ng prec) x)
+::    +neg: [@ prec] -> @
+::
+::  Two's-complement negation of a fixed-point number at its own width.
+::  (Renamed from the old +twoc, which shadowed the /lib/twoc import face
+::  and duplicated a name; behavior unchanged: -x.)
+::    Examples
+::      > (neg 0x100 [8 8])   :: -(1.0)
+::      0x1.ff00
+::  Source
+++  neg
+  |=  [x=@ =prec]
+  ^-  @
+  (neg:(ng prec) x)
+::    +hi: [@ prec @] -> @   (high n bits)
 ::  Source
 ++  hi
   |=  [x=@ =prec n=@]
-  ?>  (lte n :(^add a.prec b.prec 1))
-  =/  a  a.prec
-  =/  b  b.prec
-  ?:  =(0b0 (dis x (lsh [0 (^add a.prec b.prec)] 0b1)))
-    :: positive number or zero
-    (rsh [0 (^sub n +(a))] x)
-  :: negative number
-  =/  mask  (lsh [0 n] (rep [0 1] (reap (^sub :(^add a b 1) n) 0b1)))
-  (con (rsh [0 (^sub n +(a))] x) mask)
-::    +lo: [@ [@ @] @] -> @
-::
-::  Extract the low bits of x.  (Wordlength LO)
+  ?>  (lte n (wid prec))
+  (rsh [0 (^sub (wid prec) n)] x)
+::    +lo: [@ prec @] -> @   (low n bits)
 ::  Source
 ++  lo
   |=  [x=@ =prec n=@]
-  ?>  (lte n :(^add a.prec b.prec 1))
-  =/  b  b.prec
-  =/  a  (^sub n (^add b 1))
-  =/  mask  (rep [0 1] (reap n 0b1))
-  (dis x mask)
-::    +twoc: [@ @] -> @
+  ?>  (lte n (wid prec))
+  (dis x (dec (bex n)))
+::    +scale: [@ prec prec] -> @
 ::
-::  Produce the two's complement of x.
-::
-::  Source
-++  twoc
-  |=  [x=@ n=@]
-  %+  dis
-    (rep [0 1] (reap n 0b1))
-  (^add (mix x (rep [0 1] (reap n 0b1))) 0b1)
-::    +scale: [@ [a=@ b=@]] -> @
-::
-::  Scale x to have a bits of integer precision and b bits of fractional
-::  precision.
-::
+::  Re-quantize x from xprec to yprec (signed): shift the fractional part to
+::  the new b, then re-encode at the new width.  Saturation/rounding are not
+::  applied; high bits beyond yprec's range are dropped (wrap).
+::    Examples
+::      > (scale 0x10 [4 4] [8 8])   :: 1.0 in q4.4 -> q8.8
+::      0x100
+::      > (scale 0x100 [8 8] [4 4])  :: 1.0 in q8.8 -> q4.4
+::      0x10
 ::  Source
 ++  scale
   |=  [x=@ xprec=prec yprec=prec]
-  =/  nx  :(^add a.xprec b.xprec 1)
-  =/  lox  (lo x xprec nx)
-  =/  hix  (hi x xprec nx)
-  =/  loy  ?:  (gth b.xprec b.yprec)
-    (rsh [0 (^sub b.xprec b.yprec)] x)
-  (lsh [0 (^sub b.yprec b.xprec)] x)
-  =/  hiy  ?:  (gth a.xprec a.yprec)
-    (rsh [0 (^sub a.xprec a.yprec)] x)
-  (lsh [0 (^sub a.yprec a.xprec)] x)
-  (con (lsh hiy (^sub a.xprec b.xprec)) loy)
+  ^-  @
+  ::  decode to the signed value, rescale the fractional precision, re-encode.
+  =/  sx  (to-s x xprec)
+  =/  sg  (syn:si sx)
+  =/  mg  (abs:si sx)
+  =/  mg2  ?:  (gth b.yprec b.xprec)
+             (lsh [0 (^sub b.yprec b.xprec)] mg)
+           (rsh [0 (^sub b.xprec b.yprec)] mg)
+  (s-to-twoc:(ng yprec) (new:si sg mg2))
 --

--- a/libmath/desk/lib/twoc.hoon
+++ b/libmath/desk/lib/twoc.hoon
@@ -1,67 +1,57 @@
 |%
+::  Two's-complement signed integers, MODULAR (operations wrap mod 2^width
+::  rather than crashing on overflow -- a deliberate divergence from a
+::  checked-overflow type, matching hardware two's-complement and Lagoon's
+::  %uint wrapping).  Two doors share one implementation:
 ::
-++  twoc
-  |_  =bloq
-  ::
-  ++  len  (bex bloq)
+::  - +twid: keyed on a raw bit-WIDTH (any @), for callers like /lib/fixed
+::    whose widths are not powers of two (N = a + b + 1).
+::  - +twoc: keyed on a `bloq` (width = 2^bloq), for callers like /lib/unum
+::    and Lagoon that work in bloq-sized lanes.  It delegates to +twid at
+::    width (bex bloq), so the logic is defined once in +twid.
+::
+++  twid
+  |_  wid=@
+  ::  +len: bit width.  +len-mod: the modulus 2^width.
+  ++  len  wid
+  ++  len-mod  (bex wid)
+  ::  +msb: the sign bit (1 if the width-1 bit is set).
   ++  msb
     |=  a=@
     ?:  (^lth (xeb a) len)
       0
     1
   ++  ones  (dec len)
-  ::
-  ::
-  :: https://gist.github.com/mfuerstenau/ba870a29e16536fdbaba#file-zigzag-encoding-readme-L53
-  ::  (i >>> 1) ^ (~(i & 1) + 1)
-  ::
-  ::  Test cases
-  :: > (~(s-to-twoc twoc:twoc 2) --2)
-  ::   2
-  :: > (~(s-to-twoc twoc:twoc 2) --1)
-  ::   1
-  :: > (~(s-to-twoc twoc:twoc 2) --8)
-  ::  /lib/twoc/hoon:<[19 5].[22 45]>
-  :: > (~(s-to-twoc twoc:twoc 3) -14)
-  ::  242
+  ::  +s-to-twoc: hoon signed integer (@s) -> width-bit two's-complement.
+  ::  Wraps modularly for out-of-range inputs.
+  ::    > (~(s-to-twoc twid 8) -14)
+  ::      242
   ++  s-to-twoc
     |=  a=@s
     ^-  @
-    ?>  (^lte `@`a (dec ~(out fe bloq)))
-    %+  mix
-      (rsh 0 a)
-    (~(sum fe bloq) (not 0 len (dis a 1)) 1)
-  ::
-  :: 1001 is -7 in int4
-  :: 1111 - 1001 = 0110
-  :: 0110 + 0001 = 0111 (7)
+    =+  [sn mg]=(old:si a)
+    ?:  sn  (mod mg len-mod)
+    (neg mg)
+  ::  +twoc-to-s: width-bit two's-complement -> hoon signed integer (@s).
   ++  twoc-to-s
     |=  a=@
     ^-  @s
-    ?:  =(1 (msb a))
-      (new:si | +((^sub (dec (bex len)) a)))
-    (new:si & a)
+    ?:  =(1 (msb a))  (new:si | (abs a))
+    (new:si & (mod a len-mod))
   ::
-  ::
-  ::  Arithmetic is MODULAR two's-complement: results wrap mod 2^len rather
-  ::  than crashing on overflow.  This DIVERGES from a checked-overflow
-  ::  signed-integer type, but matches hardware two's-complement and the
-  ::  wrapping behavior of Lagoon's %uint (fe) scalars.  Because the low len
-  ::  bits of a sum/product are independent of sign, the same bit-level add
-  ::  and multiply serve signed and unsigned alike.
+  ::  Arithmetic.  Because the low `len` bits of a sum/product are independent
+  ::  of sign, the same bit-level add and multiply serve signed and unsigned.
   ::
   ++  add  |=([a=@ b=@] ^-(@ (mod (^add a b) len-mod)))
-  ::  +neg: two's-complement negation, ~a + 1 (flip the len bits, add one),
-  ::  the standard XOR-then-increment.  neg(min) = min (wraps).
+  ::  +neg: two's-complement negation, ~a + 1 (flip the len bits, add one).
+  ::  neg(min) = min (wraps).
   ++  neg  |=(a=@ ^-(@ (mod +((not 0 len (mod a len-mod))) len-mod)))
   ++  sub  |=([a=@ b=@] ^-(@ (add a (neg b))))
   ++  mul  |=([a=@ b=@] ^-(@ (mod (^mul (mod a len-mod) (mod b len-mod)) len-mod)))
   ::  +abs: |a| as a two's-complement value (abs(min) wraps back to min).
   ++  abs  |=(a=@ ^-(@ ?:(=(1 (msb a)) (neg a) (mod a len-mod))))
-  ::  +len-mod: 2^len, the modulus (len is the bit width = 2^bloq).
-  ++  len-mod  (bex len)
   ::  +overflow: would a + b overflow a CHECKED signed add?  Retained for
-  ::  callers that want to detect, rather than wrap; +add no longer uses it.
+  ::  callers that want to detect rather than wrap; +add no longer uses it.
   ++  overflow
     |=  [a=@ b=@ c=@]
     ?|  &(=(0 (msb c)) =(1 (msb a)) =(1 (msb b)))
@@ -75,18 +65,17 @@
     =/  sa  (msb a)
     =/  sb  (msb b)
     =/  q   (^div (abs a) (abs b))
-    ?:  =(sa sb)  (mod q len-mod)            :: same sign -> non-negative
-    (neg q)                                  :: opposite sign -> negative
+    ?:  =(sa sb)  (mod q len-mod)
+    (neg q)
   ::  +rem: signed remainder, sign follows the DIVIDEND (C `%` / truncated).
   ::  a == (add (mul (div a b) b) (rem a b)).
   ++  rem
     |=  [a=@ b=@]
     ^-  @
     =/  r  (mod (abs a) (abs b))
-    ?:  =(0 (msb a))  (mod r len-mod)        :: dividend non-negative
-    (neg r)                                  :: dividend negative
-  ::  +pow: a to a NON-NEGATIVE integer power n (n a raw @, not two's-comp),
-  ::  by modular squaring.  pow(a, 0) = 1.
+    ?:  =(0 (msb a))  (mod r len-mod)
+    (neg r)
+  ::  +pow: a to a NON-NEGATIVE integer power n (raw @), by modular squaring.
   ++  pow
     |=  [a=@ n=@]
     ^-  @
@@ -96,36 +85,50 @@
     ?:  =(0 n)  acc
     =?  acc  =(1 (dis n 1))  (mul acc base)
     $(n (rsh 0 n), base (mul base base))
-  ::
-  ::
+  ::  +extend: sign-extension fill (all-ones if negative, else zero).
   ++  extend
     |=  a=@
     ^-  @
     ?:  =((msb a) 0)
       0
     (dec (bex len))
-  ::
-  ::
-  ::  > (~(gth twoc:twoc 3) `@ub`0b1010.1111 `@ub`0b1010.1110)
-  ::    %.y
-  ::
-  ::  > (~(gth twoc:twoc 3) 256 126)
-  ::    %.n
-  ::
+  ::  Comparisons, by two's-complement order (negatives below non-negatives).
   ++  gth
     |=  [a=@ b=@]
-    ::
-    ::  check for different signs
     ?:  =(1 (mix (msb a) (msb b)))
-      ::
-      ::  if different, choose the one that is positive
       =(0 (msb a))
-    ::
-    ::  if signs same, use the default gth
     (^gth a b)
-  ::
   ++  lth  |=([a=@ b=@] (gth b a))
   ++  lte  |=([a=@ b=@] !(gth a b))
   ++  gte  |=([a=@ b=@] !(gth b a))
+  --
+::
+::  +twoc: bloq-keyed facade over +twid (width = 2^bloq).  Logic lives in
+::  +twid; these arms just re-export it at the delegated width, so existing
+::  callers `~(add twoc:twoc bloq)` keep working unchanged.
+::
+++  twoc
+  |_  =bloq
+  +*  w  ~(. twid (bex bloq))
+  ++  len        len:w
+  ++  len-mod    len-mod:w
+  ++  msb        msb:w
+  ++  ones       ones:w
+  ++  s-to-twoc  s-to-twoc:w
+  ++  twoc-to-s  twoc-to-s:w
+  ++  add        add:w
+  ++  neg        neg:w
+  ++  sub        sub:w
+  ++  mul        mul:w
+  ++  abs        abs:w
+  ++  overflow   overflow:w
+  ++  div        div:w
+  ++  rem        rem:w
+  ++  pow        pow:w
+  ++  extend     extend:w
+  ++  gth        gth:w
+  ++  lth        lth:w
+  ++  lte        lte:w
+  ++  gte        gte:w
   --
 --

--- a/libmath/desk/tests/lib/fixed.hoon
+++ b/libmath/desk/tests/lib/fixed.hoon
@@ -1,0 +1,66 @@
+  ::  /tests/lib/fixed
+::::
+::    Fixed-point arithmetic (signed, modular), built on /lib/twoc.
+::    q8.8 = prec [8 8], N = 17.  Negative operands are the cases the old
+::    unsigned mul/div/scale got wrong; the scale crash is also covered.
+::
+/+  *test,
+    fixed
+^|
+=/  q88=prec:fixed  [8 8]
+=/  n1-5  (neg:fixed 0x180 q88)   :: -1.5 in q8.8 = 0x1.fe80
+=/  n3    (neg:fixed 0x300 q88)   :: -3.0 in q8.8 = 0x1.fd00
+|%
+++  test-add  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x3c0)     !>((add:fixed 0x180 q88 0x240 q88))  ::  1.5+2.25=3.75
+    %+  expect-eq  !>(`@`0x200)     !>((add:fixed 0x100 q88 0x100 q88))  ::  1+1=2
+    %+  expect-eq  !>(`@`0x1.ff80)  !>((add:fixed 0x100 q88 n1-5 q88))   ::  1+(-1.5)=-0.5
+  ==
+::
+++  test-sub  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x1.ff00)  !>((sub:fixed 0x100 q88 0x200 q88))  ::  1-2=-1
+    %+  expect-eq  !>(`@`0x100)     !>((sub:fixed 0x200 q88 0x100 q88))  ::  2-1=1
+  ==
+::
+++  test-neg  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x1.ff00)  !>((neg:fixed 0x100 q88))   ::  -(1.0)
+    %+  expect-eq  !>(`@`0x1.fe80)  !>((neg:fixed 0x180 q88))   ::  -(1.5)
+    %+  expect-eq  !>(`@`0x100)     !>((neg:fixed (neg:fixed 0x100 q88) q88))  ::  --1=1
+  ==
+::
+::  mul widens precision to [17 16] (N=34).  Negative cases the old unsigned
+::  mul returned garbage for.  -3.0 in q17.16 is 0x3.fffd.0000.
+++  test-mul  ^-  tang
+  =/  prodp=prec:fixed  [17 16]
+  ;:  weld
+    %+  expect-eq  !>([0x3.0000 prodp])       !>((mul:fixed 0x180 q88 0x200 q88))
+    %+  expect-eq  !>([0x3.fffd.0000 prodp])  !>((mul:fixed n1-5 q88 0x200 q88))
+    %+  expect-eq  !>([0x3.0000 prodp])       !>((mul:fixed n1-5 q88 (neg:fixed 0x200 q88) q88))
+  ==
+::
+::  div keeps precision [8 8].  Negative cases the old unsigned div got wrong.
+++  test-div  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>([0x1.fe80 q88])  !>((div:fixed n3 q88 0x200 q88))   ::  -3/2=-1.5
+    %+  expect-eq  !>([0x180 q88])     !>((div:fixed 0x300 q88 0x200 q88))  ::  3/2=1.5
+    %+  expect-eq  !>([0x180 q88])     !>((div:fixed n3 q88 (neg:fixed 0x200 q88) q88))  ::  -3/-2=1.5
+  ==
+::
+::  scale (the old version crashed on widen via a bad lsh; now correct).
+::  -1.5 in q4.4 (N=9) is 0x1e8.
+++  test-scale  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x100)  !>((scale:fixed 0x10 [4 4] [8 8]))   ::  1.0 q4.4 -> q8.8
+    %+  expect-eq  !>(`@`0x10)   !>((scale:fixed 0x100 [8 8] [4 4]))  ::  1.0 q8.8 -> q4.4
+    %+  expect-eq  !>(`@`0x1e8)  !>((scale:fixed n1-5 [8 8] [4 4]))   ::  -1.5 q8.8 -> q4.4
+  ==
+::
+::  round-trip: (3.0/2.0) then *2.0 = 3.0 (exact here).
+++  test-div-roundtrip  ^-  tang
+  =/  q  (div:fixed 0x300 q88 0x200 q88)        ::  3.0/2.0 = 1.5 in q8.8
+  =/  back  (mul:fixed -.q q88 0x200 q88)       ::  1.5*2.0 = 3.0 in q17.16
+  %+  expect-eq  !>(`@`0x3.0000)  !>(-.back)
+--

--- a/libmath/desk/tests/lib/twoc.hoon
+++ b/libmath/desk/tests/lib/twoc.hoon
@@ -1,17 +1,20 @@
   ::  /tests/lib/twoc
 ::::
 ::    Two's-complement integer arithmetic (modular).  The bulk of the
-::    arithmetic is checked at int8 (bloq 3); the wrap boundaries and the
-::    len/len-mod modulus are re-checked at int16 (bloq 4), int32 (bloq 5),
-::    and int64 (bloq 6) so width handling is exercised at several sizes.
+::    arithmetic is checked at int8 (bloq 3) through the +twoc facade; the
+::    wrap boundaries are re-checked at int16/32/64.  The width-keyed +twid
+::    door is exercised directly at a non-power-of-2 width (17) -- the case
+::    /lib/fixed needs -- plus a facade/width parity check.
 ::
 /+  *test,
     twoc
 ^|
-=/  t  ~(. twoc:twoc 3)            :: int8
+=/  t  ~(. twoc:twoc 3)            :: int8 (facade)
 =/  t16  ~(. twoc:twoc 4)          :: int16
 =/  t32  ~(. twoc:twoc 5)          :: int32
 =/  t64  ~(. twoc:twoc 6)          :: int64
+=/  w17  ~(. twid:twoc 17)         :: width-17 (q8.8 fixed N)
+=/  w8   ~(. twid:twoc 8)          :: width-8, should match the bloq-3 facade
 |%
 ++  test-add  ^-  tang
   ;:  weld
@@ -109,5 +112,31 @@
     %+  expect-eq  !>(`@`0x1)                    !>((mul:t64 0xffff.ffff.ffff.ffff 0xffff.ffff.ffff.ffff))  ::  -1*-1=1
     %+  expect-eq  !>(`@`0xffff.ffff.ffff.fffe)  !>((mul:t64 0xffff.ffff.ffff.ffff 0x2))   ::  -1*2=-2
     %+  expect-eq  !>(%.y)                       !>((lth:t64 0xffff.ffff.ffff.ffff 0x1))   ::  -1 < 1
+  ==
+::
+::  +twid at a non-power-of-2 width (17): the case /lib/fixed needs.
+::  Sign bit is bit 16 (0x1.0000); max positive is 0xffff, min is 0x1.0000.
+++  test-twid17  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x1.ffff)  !>((neg:w17 0x1))             ::  -1
+    %+  expect-eq  !>(`@`0x1.0000)  !>((add:w17 0xffff 0x1))      ::  maxpos+1 -> min (wrap)
+    %+  expect-eq  !>(`@`0x1.fffa)  !>((mul:w17 (neg:w17 0x3) 0x2))  ::  -3*2=-6
+    %+  expect-eq  !>(`@`0x6)       !>((mul:w17 (neg:w17 0x3) (neg:w17 0x2)))  ::  -3*-2=6
+    %+  expect-eq  !>(%.y)          !>((lth:w17 0x1.ffff 0x1))    ::  -1 < 1
+    %+  expect-eq  !>(`@`0x5)       !>((abs:w17 0x1.fffb))        ::  |-5|=5
+    %+  expect-eq  !>(`@`0x5)       !>((s-to-twoc:w17 --5))       ::  +5
+    %+  expect-eq  !>(`@`0x1.fffb)  !>((s-to-twoc:w17 -5))        ::  -5
+    %+  expect-eq  !>(`@s`-5)       !>((twoc-to-s:w17 0x1.fffb))  ::  round trip back
+    %+  expect-eq  !>(`@s`--5)      !>((twoc-to-s:w17 0x5))
+  ==
+::
+::  facade/width parity: +twoc at bloq 3 must equal +twid at width 8.
+++  test-facade-parity  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>((add:t 0x64 0x32))   !>((add:w8 0x64 0x32))
+    %+  expect-eq  !>((mul:t 0xfb 0x2))    !>((mul:w8 0xfb 0x2))
+    %+  expect-eq  !>((div:t 0xf9 0x2))    !>((div:w8 0xf9 0x2))
+    %+  expect-eq  !>((neg:t 0x1))         !>((neg:w8 0x1))
+    %+  expect-eq  !>((rem:t 0xf9 0x2))    !>((rem:w8 0xf9 0x2))
   ==
 --

--- a/libmath/tools/fixed_check.py
+++ b/libmath/tools/fixed_check.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Offline oracle harness for /lib/fixed (fixed-point Q a.b).
+
+Cross-checks a Python mirror of the Hoon /lib/fixed algorithm against TWO
+independent oracles:
+
+  1. exact rationals (`fractions.Fraction`) -- a fixed-point value is exactly
+     scaledval / 2^b, so this is ground truth with no rounding of its own.
+  2. the `spfpm` library (the `FixedPoint` module), an established third-party
+     fixed-point implementation.
+
+A fixed-point number here is a two's-complement integer of N = a+b+1 bits
+interpreted as value/2^b (sign bit at N-1).  Arithmetic is signed and modular
+(wraps mod 2^N), matching the Hoon library and /lib/twoc.
+
+    pip install spfpm
+    python3 libmath/tools/fixed_check.py
+"""
+from fractions import Fraction
+try:
+    from FixedPoint import FXfamily, FXnum
+except ImportError:
+    FXnum = None
+
+# ---- mirror of the Hoon /lib/fixed (delegates to twoc width N=a+b+1) ----
+
+def nof(a, b):              return a + b + 1
+def s2t(s, n):             return s % (1 << n)              # signed int -> N bits
+def t2s(t, n):             return t - (1 << n) if t >> (n - 1) else t
+
+def f_add(x, xp, y, yp):
+    n = nof(*xp); return (x + y) % (1 << n)
+def f_sub(x, xp, y, yp):
+    n = nof(*xp); return (x - y) % (1 << n)
+def f_neg(x, xp):
+    n = nof(*xp); return (-t2s(x, n)) % (1 << n)
+def f_mul(x, xp, y, yp):
+    pa, pb = xp[0] + yp[0] + 1, xp[1] + yp[1]; n = nof(pa, pb)
+    return ((t2s(x, nof(*xp)) * t2s(y, nof(*yp))) % (1 << n), (pa, pb))
+def f_div(x, xp, y, yp):
+    n = nof(*xp); sx = t2s(x, n); sy = t2s(y, nof(*yp))
+    num = sx << xp[1]
+    q = abs(num) // abs(sy)
+    if (num < 0) != (sy < 0): q = -q
+    return (q % (1 << n), xp)
+def f_scale(x, xp, yp):
+    nx, ny = nof(*xp), nof(*yp); sx = t2s(x, nx)
+    sg = sx >= 0; mg = abs(sx)
+    mg2 = mg << (yp[1] - xp[1]) if yp[1] > xp[1] else mg >> (xp[1] - yp[1])
+    v = mg2 if sg else -mg2
+    return v % (1 << ny)
+
+# ---- value views ----
+
+def fxval(bits, a, b):     return Fraction(t2s(bits, nof(a, b)), 1 << b)  # exact value
+
+# ---- checks ----
+
+def near(x, y, tol=Fraction(0)):
+    return abs(x - y) <= tol
+
+def check_exact():
+    """Mirror ops vs exact-rational expectation.
+
+    The reference accounts for the library's MODULAR wrap: a result is the
+    true rational re-encoded into the result width and decoded back, so an
+    out-of-range value wraps exactly as the Hoon does.
+    """
+    a, b = 8, 8
+    samples = [Fraction(3, 2), Fraction(-3, 2), Fraction(9, 4), Fraction(-1),
+               Fraction(5), Fraction(-7, 1), Fraction(1, 256)]
+    def enc(v, bb=b):  return s2t(int(v * (1 << bb)), nof(a, b))   # value -> q8.8 bits
+    def wrap(v, ra, rb):                       # true value -> (re-encoded) value at qRa.Rb
+        return fxval(s2t(int(v * (1 << rb)), nof(ra, rb)), ra, rb)
+    def trunc(q):                              # truncate toward zero to 1/2^b
+        return Fraction(int(q * 256), 256) if q >= 0 else -Fraction(int(-q * 256), 256)
+    ok = True
+    for x in samples:
+        for y in samples:
+            bx, by = enc(x), enc(y)
+            if fxval(f_add(bx, (a, b), by, (a, b)), a, b) != wrap(x + y, a, b):
+                ok = False; print("add", x, y)
+            if fxval(f_sub(bx, (a, b), by, (a, b)), a, b) != wrap(x - y, a, b):
+                ok = False; print("sub", x, y)
+            mb, mp = f_mul(bx, (a, b), by, (a, b))
+            if fxval(mb, mp[0], mp[1]) != wrap(x * y, mp[0], mp[1]):
+                ok = False; print("mul", x, y)
+            if y != 0:
+                db, dp = f_div(bx, (a, b), by, (a, b))
+                if fxval(db, dp[0], dp[1]) != wrap(trunc(x / y), dp[0], dp[1]):
+                    ok = False; print("div", x, y, float(fxval(db, dp[0], dp[1])))
+    print("exact-rational: add/sub/mul/div over samples^2 (with wrap):",
+          "OK" if ok else "MISMATCH")
+    return ok
+
+def check_spfpm():
+    """Parity with the spfpm library on IN-RANGE results.  spfpm is a CHECKED
+    (overflow-raising) type, so it can only witness cases that don't wrap;
+    we skip any op whose result leaves q8.8 range and let check_exact cover
+    the wrapping cases.
+    """
+    if FXnum is None:
+        print("spfpm: SKIP (not installed)"); return True
+    a, b = 8, 8
+    fam = FXfamily(b, a)
+    # q8.8 holds signed scaledval in [-2^15, 2^15-1].  spfpm's FXfamily(8,8)
+    # validates the same magnitude range, so we keep operands and results
+    # strictly inside it (it raises on overflow rather than wrapping).
+    lo, hi = -(1 << 15), (1 << 15) - 1
+    import random; random.seed(3); ok = True; checked = 0
+    def mk(s):
+        v = FXnum(0, fam); v.scaledval = s; return v
+    while checked < 8000:
+        sx = random.randrange(lo, hi + 1)
+        sy = random.randrange(lo, hi + 1)
+        bx, by = s2t(sx, nof(a, b)), s2t(sy, nof(a, b))
+        for op, res in (('add', sx + sy), ('sub', sx - sy)):
+            if not (lo <= res <= hi):  continue
+            r = (mk(sx) + mk(sy)) if op == 'add' else (mk(sx) - mk(sy))
+            mine = f_add(bx, (a, b), by, (a, b)) if op == 'add' else f_sub(bx, (a, b), by, (a, b))
+            if fxval(mine, a, b) != Fraction(r.scaledval, 1 << b):
+                ok = False; print(op, sx, sy)
+            checked += 1
+    print(f"spfpm: add/sub parity on {checked} in-range q8.8 cases:",
+          "OK" if ok else "MISMATCH")
+    return ok
+
+if __name__ == '__main__':
+    e = check_exact()
+    s = check_spfpm()
+    print("ALL PASS:", e and s)


### PR DESCRIPTION
Fixes the fixed-point bugs found in review (mul/div wrong for negatives; scale crash) by rebuilding `/lib/fixed` on the shared, tested `/lib/twoc` instead of its own ad-hoc two's-complement code.

## Bugs fixed (all confirmed on `~hex` before the fix)

- **`mul` wrong for negatives** — did unsigned `^mul` on two's-complement bit patterns. `mul(-1.5, 2.0)` q8.8 returned +1021.0 (want −3.0).
- **`div` wrong for negatives** — same root cause. `div(-3.0, 2.0)` returned +254.5 (want −1.5).
- **`scale` broken** — dead `hi`/`lo` split (computed, never used) and a final `(lsh hiy …)` that passed a *value* as the `lsh` bloq count, shifting by ~2^256 bits and **crashing** on any widening scale.

## `/lib/twoc` — width-keyed door (option B, no churn to existing callers)

- New `++twid` keyed on a raw bit-**width** holds the whole implementation (works at any width, including fixed's non-power-of-2 `N = a+b+1`).
- `++twoc` (bloq-keyed) becomes a thin facade: `+* w ~(. twid (bex bloq))`, re-exporting each arm. So the 17 existing call sites in `/lib/unum` and `lagoon.hoon` are untouched and logic lives once.
- `s-to-twoc`/`twoc-to-s` rewritten width-native (dropped the bloq-only `fe`).

## `/lib/fixed` — rebuilt

`/+ twoc`; `++ng |=(=prec ~(. twid:twoc (wid prec)))` yields the width-N door, and `add`/`sub`/`neg`/`mul`/`div`/`scale` delegate to it (signed-correct, modular). `mul` widens precision to `[a.x+a.y+1, b.x+b.y]`; `div` scales the dividend by `2^b` then signed-divides truncating toward zero. The old `++twoc` arm — which shadowed the `/+ twoc` import face *and* duplicated a name — is renamed **`++neg`** (behavior unchanged); `++to-s` decodes to `@s`.

## Tests & oracle

- New `/tests/lib/fixed` (7 arms: add/sub/neg/mul/div/scale + a div→mul round-trip, all with negative operands and the former scale-crash case) — pass on `~hex`.
- `/tests/lib/twoc` gains `test-twid17` (non-power-of-2 width) and `test-facade-parity` (bloq-3 == width-8); `unum`/`lagoon-int2` suites still green.
- New offline harness `libmath/tools/fixed_check.py`: dual oracle — exact `fractions.Fraction` (modelling the modular wrap) **and** the `spfpm` `FixedPoint` library (in-range cases, since it's overflow-checked). ALL PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)