### PR TITLE
Wire %unum (posit) arrays into Lagoon

### DIFF
--- a/lagoon/desk/lib/lagoon.hoon
+++ b/lagoon/desk/lib/lagoon.hoon
@@ -1,5 +1,5 @@
 /-  lagoon
-/+  twoc
+/+  twoc, unum
 =+  lagoon
 ::                                                    ::
 ::::                    ++la                          ::  (2v) vector/matrix ops
@@ -66,6 +66,15 @@
         %6  %rd
         %5  %rs
         %4  %rh
+      ==
+      ::
+        %unum
+      ::  no decimal pretty-printer yet; print the raw posit aura.
+      ?+    bloq.meta  ~|(bloq.meta !!)
+        %6  %rpd
+        %5  %rps
+        %4  %rph
+        %3  %rpb
       ==
     ==
   ::
@@ -458,6 +467,14 @@
         %5  .1
         %4  .~~1
       ==
+      ::
+        %unum
+      ?+  bloq.meta  ~|(bloq.meta !!)
+        %6  one:rpd:unum
+        %5  one:rps:unum
+        %4  one:rph:unum
+        %3  one:rpb:unum
+      ==
     ==
   ::    Zeroes
   ++  zeros
@@ -481,6 +498,14 @@
           %6  .~1
           %5  .1
           %4  .~~1
+        ==
+        ::
+          %unum
+        ?+  bloq.meta  !!
+          %6  one:rpd:unum
+          %5  one:rps:unum
+          %4  one:rph:unum
+          %3  one:rpb:unum
         ==
       ==
     (fill meta one)
@@ -626,6 +651,10 @@
       (spac [meta `@ux`data])
       ::
         %int2
+      (spac [meta `@ux`data])
+      ::
+        %unum
+      ::  data is already a posit bit pattern; pack it raw, like %int2.
       (spac [meta `@ux`data])
       ::
         %i754
@@ -1124,6 +1153,74 @@
           %neq  |=([a=@rh b=@rh] ?:(.=(a b) .~~0 .~~1))
         ==
       ==  :: bloq real
+      ::
+        %unum
+      ::  posits (/lib/unum), bloq selects width: 3=rpb 4=rph 5=rps 6=rpd.
+      ::  arithmetic is correctly-rounded per the 2022 standard; comparisons
+      ::  return posit 1 / 0 (i.e. `one` / `zero`) to match the value
+      ::  convention of the other kinds.  %mod is a - b*trunc(a/b).
+      ?+    `^bloq`bloq  !!
+          %3
+        ?+  fun  !!
+          %add  add:rpb:unum
+          %sub  sub:rpb:unum
+          %mul  mul:rpb:unum
+          %div  div:rpb:unum
+          %mod  |=([a=@ b=@] (sub:rpb:unum a (mul:rpb:unum b (san:rpb:unum (need (toi:rpb:unum (div:rpb:unum a b)))))))
+          %pow  |=([a=@ b=@] (pow-n:rpb:unum a `@u`(abs:si (need (toi:rpb:unum b)))))
+          %gth  |=([a=@ b=@] ?:((gth:rpb:unum a b) one:rpb:unum zero:rpb:unum))
+          %gte  |=([a=@ b=@] ?:((gte:rpb:unum a b) one:rpb:unum zero:rpb:unum))
+          %lth  |=([a=@ b=@] ?:((lth:rpb:unum a b) one:rpb:unum zero:rpb:unum))
+          %lte  |=([a=@ b=@] ?:((lte:rpb:unum a b) one:rpb:unum zero:rpb:unum))
+          %equ  |=([a=@ b=@] ?:((equ:rpb:unum a b) one:rpb:unum zero:rpb:unum))
+          %neq  |=([a=@ b=@] ?:((neq:rpb:unum a b) one:rpb:unum zero:rpb:unum))
+        ==
+          %4
+        ?+  fun  !!
+          %add  add:rph:unum
+          %sub  sub:rph:unum
+          %mul  mul:rph:unum
+          %div  div:rph:unum
+          %mod  |=([a=@ b=@] (sub:rph:unum a (mul:rph:unum b (san:rph:unum (need (toi:rph:unum (div:rph:unum a b)))))))
+          %pow  |=([a=@ b=@] (pow-n:rph:unum a `@u`(abs:si (need (toi:rph:unum b)))))
+          %gth  |=([a=@ b=@] ?:((gth:rph:unum a b) one:rph:unum zero:rph:unum))
+          %gte  |=([a=@ b=@] ?:((gte:rph:unum a b) one:rph:unum zero:rph:unum))
+          %lth  |=([a=@ b=@] ?:((lth:rph:unum a b) one:rph:unum zero:rph:unum))
+          %lte  |=([a=@ b=@] ?:((lte:rph:unum a b) one:rph:unum zero:rph:unum))
+          %equ  |=([a=@ b=@] ?:((equ:rph:unum a b) one:rph:unum zero:rph:unum))
+          %neq  |=([a=@ b=@] ?:((neq:rph:unum a b) one:rph:unum zero:rph:unum))
+        ==
+          %5
+        ?+  fun  !!
+          %add  add:rps:unum
+          %sub  sub:rps:unum
+          %mul  mul:rps:unum
+          %div  div:rps:unum
+          %mod  |=([a=@ b=@] (sub:rps:unum a (mul:rps:unum b (san:rps:unum (need (toi:rps:unum (div:rps:unum a b)))))))
+          %pow  |=([a=@ b=@] (pow-n:rps:unum a `@u`(abs:si (need (toi:rps:unum b)))))
+          %gth  |=([a=@ b=@] ?:((gth:rps:unum a b) one:rps:unum zero:rps:unum))
+          %gte  |=([a=@ b=@] ?:((gte:rps:unum a b) one:rps:unum zero:rps:unum))
+          %lth  |=([a=@ b=@] ?:((lth:rps:unum a b) one:rps:unum zero:rps:unum))
+          %lte  |=([a=@ b=@] ?:((lte:rps:unum a b) one:rps:unum zero:rps:unum))
+          %equ  |=([a=@ b=@] ?:((equ:rps:unum a b) one:rps:unum zero:rps:unum))
+          %neq  |=([a=@ b=@] ?:((neq:rps:unum a b) one:rps:unum zero:rps:unum))
+        ==
+          %6
+        ?+  fun  !!
+          %add  add:rpd:unum
+          %sub  sub:rpd:unum
+          %mul  mul:rpd:unum
+          %div  div:rpd:unum
+          %mod  |=([a=@ b=@] (sub:rpd:unum a (mul:rpd:unum b (san:rpd:unum (need (toi:rpd:unum (div:rpd:unum a b)))))))
+          %pow  |=([a=@ b=@] (pow-n:rpd:unum a `@u`(abs:si (need (toi:rpd:unum b)))))
+          %gth  |=([a=@ b=@] ?:((gth:rpd:unum a b) one:rpd:unum zero:rpd:unum))
+          %gte  |=([a=@ b=@] ?:((gte:rpd:unum a b) one:rpd:unum zero:rpd:unum))
+          %lth  |=([a=@ b=@] ?:((lth:rpd:unum a b) one:rpd:unum zero:rpd:unum))
+          %lte  |=([a=@ b=@] ?:((lte:rpd:unum a b) one:rpd:unum zero:rpd:unum))
+          %equ  |=([a=@ b=@] ?:((equ:rpd:unum a b) one:rpd:unum zero:rpd:unum))
+          %neq  |=([a=@ b=@] ?:((neq:rpd:unum a b) one:rpd:unum zero:rpd:unum))
+        ==
+      ==  :: bloq unum
     ==  :: kind
   ::
   ++  trans-scalar
@@ -1158,6 +1255,14 @@
         ?+  fun  !!
           %abs  |=(b=@ ?:((~(gte rh rnd) b .~~0) b (~(mul rh rnd) b .~~-1)))
         ==
+      ==
+      ::
+        %unum
+      ?+    bloq  !!
+        %6  ?+(fun !! %abs abs:rpd:unum)
+        %5  ?+(fun !! %abs abs:rps:unum)
+        %4  ?+(fun !! %abs abs:rph:unum)
+        %3  ?+(fun !! %abs abs:rpb:unum)
       ==
     ==
   ::

--- a/lagoon/desk/lib/lagoon.hoon
+++ b/lagoon/desk/lib/lagoon.hoon
@@ -69,7 +69,8 @@
       ==
       ::
         %unum
-      ::  no decimal pretty-printer yet; print the raw posit aura.
+      ::  no decimal pretty-printer yet; the @rpb/@rph/@rps/@rpd auras are
+      ::  not registered with the printer, so values render as raw hex.
       ?+    bloq.meta  ~|(bloq.meta !!)
         %6  %rpd
         %5  %rps
@@ -432,6 +433,10 @@
         :-  [shape.meta.ray bloq %i754 tail.meta.ray]
         data:(de-ray ray)
       ==
+      ::  %unum conversion (to/from posits) is not yet wired; see the unum
+      ::  to-r*/from-r* matrix in /lib/unum for the eventual mapping.
+        %unum
+      ~|('lagoon: change/convert not yet implemented for %unum' !!)
     ==
   ::
   ::  Builders
@@ -705,6 +710,8 @@
     ?>  (check a)
     +:(find ~[(get-item (min a) ~[0 0])] (ravel a))
   ::
+  ::  NB: despite the name, this is a full reduction to a scalar (the total
+  ::  sum), not a running/prefix cumulative sum.
   ++  cumsum
     ~/  %cumsum
     |=  a=ray
@@ -1099,6 +1106,62 @@
     |=  [=bloq v=(list @)]
     ^-  @
     (unum-fdp bloq v (reap (lent v) (unum-one bloq)))
+  ::  +unum-mod: posit remainder a - b*trunc(a/b), the quotient truncated
+  ::  TOWARD ZERO (C fmod / remainder-with-sign-of-dividend).  Returns nar on
+  ::  a NaR operand or division by zero (b = posit 0) rather than crashing.
+  ++  unum-mod
+    |=  [=bloq a=@ b=@]
+    ^-  @
+    ?+  bloq  !!
+        %3
+      =/  q  (div:rpb:unum a b)
+      ?:  =(nar:rpb:unum q)  nar:rpb:unum
+      =/  t  ?:((gte:rpb:unum q zero:rpb:unum) (flr:rpb:unum q) (cel:rpb:unum q))
+      (sub:rpb:unum a (mul:rpb:unum b t))
+        %4
+      =/  q  (div:rph:unum a b)
+      ?:  =(nar:rph:unum q)  nar:rph:unum
+      =/  t  ?:((gte:rph:unum q zero:rph:unum) (flr:rph:unum q) (cel:rph:unum q))
+      (sub:rph:unum a (mul:rph:unum b t))
+        %5
+      =/  q  (div:rps:unum a b)
+      ?:  =(nar:rps:unum q)  nar:rps:unum
+      =/  t  ?:((gte:rps:unum q zero:rps:unum) (flr:rps:unum q) (cel:rps:unum q))
+      (sub:rps:unum a (mul:rps:unum b t))
+        %6
+      =/  q  (div:rpd:unum a b)
+      ?:  =(nar:rpd:unum q)  nar:rpd:unum
+      =/  t  ?:((gte:rpd:unum q zero:rpd:unum) (flr:rpd:unum q) (cel:rpd:unum q))
+      (sub:rpd:unum a (mul:rpd:unum b t))
+    ==
+  ::  +unum-pow: a raised to an integer power.  The exponent posit b is taken
+  ::  to its nearest integer (via toi); a NEGATIVE exponent yields the
+  ::  reciprocal a^-n = 1/(a^n).  Returns nar if b is NaR.
+  ++  unum-pow
+    |=  [=bloq a=@ b=@]
+    ^-  @
+    ?+  bloq  !!
+        %3
+      =/  ui  (toi:rpb:unum b)
+      ?~  ui  nar:rpb:unum
+      =/  p  (pow-n:rpb:unum a `@u`(abs:si u.ui))
+      ?:((lth:rpb:unum b zero:rpb:unum) (div:rpb:unum one:rpb:unum p) p)
+        %4
+      =/  ui  (toi:rph:unum b)
+      ?~  ui  nar:rph:unum
+      =/  p  (pow-n:rph:unum a `@u`(abs:si u.ui))
+      ?:((lth:rph:unum b zero:rph:unum) (div:rph:unum one:rph:unum p) p)
+        %5
+      =/  ui  (toi:rps:unum b)
+      ?~  ui  nar:rps:unum
+      =/  p  (pow-n:rps:unum a `@u`(abs:si u.ui))
+      ?:((lth:rps:unum b zero:rps:unum) (div:rps:unum one:rps:unum p) p)
+        %6
+      =/  ui  (toi:rpd:unum b)
+      ?~  ui  nar:rpd:unum
+      =/  p  (pow-n:rpd:unum a `@u`(abs:si u.ui))
+      ?:((lth:rpd:unum b zero:rpd:unum) (div:rpd:unum one:rpd:unum p) p)
+    ==
   ::
   +$  ops   $?  %add
                 %sub
@@ -1218,7 +1281,10 @@
       ::  posits (/lib/unum), bloq selects width: 3=rpb 4=rph 5=rps 6=rpd.
       ::  arithmetic is correctly-rounded per the 2022 standard; comparisons
       ::  return posit 1 / 0 (i.e. `one` / `zero`) to match the value
-      ::  convention of the other kinds.  %mod is a - b*trunc(a/b).
+      ::  convention of the other kinds.  %mod is the truncated remainder
+      ::  a - b*trunc(a/b) (see +unum-mod); %pow raises to an integer exponent,
+      ::  negative -> reciprocal (see +unum-pow).  Both return nar on a NaR
+      ::  operand or division by zero rather than crashing.
       ?+    `^bloq`bloq  !!
           %3
         ?+  fun  !!
@@ -1226,8 +1292,8 @@
           %sub  sub:rpb:unum
           %mul  mul:rpb:unum
           %div  div:rpb:unum
-          %mod  |=([a=@ b=@] (sub:rpb:unum a (mul:rpb:unum b (san:rpb:unum (need (toi:rpb:unum (div:rpb:unum a b)))))))
-          %pow  |=([a=@ b=@] (pow-n:rpb:unum a `@u`(abs:si (need (toi:rpb:unum b)))))
+          %mod  |=([a=@ b=@] (unum-mod %3 a b))
+          %pow  |=([a=@ b=@] (unum-pow %3 a b))
           %gth  |=([a=@ b=@] ?:((gth:rpb:unum a b) one:rpb:unum zero:rpb:unum))
           %gte  |=([a=@ b=@] ?:((gte:rpb:unum a b) one:rpb:unum zero:rpb:unum))
           %lth  |=([a=@ b=@] ?:((lth:rpb:unum a b) one:rpb:unum zero:rpb:unum))
@@ -1241,8 +1307,8 @@
           %sub  sub:rph:unum
           %mul  mul:rph:unum
           %div  div:rph:unum
-          %mod  |=([a=@ b=@] (sub:rph:unum a (mul:rph:unum b (san:rph:unum (need (toi:rph:unum (div:rph:unum a b)))))))
-          %pow  |=([a=@ b=@] (pow-n:rph:unum a `@u`(abs:si (need (toi:rph:unum b)))))
+          %mod  |=([a=@ b=@] (unum-mod %4 a b))
+          %pow  |=([a=@ b=@] (unum-pow %4 a b))
           %gth  |=([a=@ b=@] ?:((gth:rph:unum a b) one:rph:unum zero:rph:unum))
           %gte  |=([a=@ b=@] ?:((gte:rph:unum a b) one:rph:unum zero:rph:unum))
           %lth  |=([a=@ b=@] ?:((lth:rph:unum a b) one:rph:unum zero:rph:unum))
@@ -1256,8 +1322,8 @@
           %sub  sub:rps:unum
           %mul  mul:rps:unum
           %div  div:rps:unum
-          %mod  |=([a=@ b=@] (sub:rps:unum a (mul:rps:unum b (san:rps:unum (need (toi:rps:unum (div:rps:unum a b)))))))
-          %pow  |=([a=@ b=@] (pow-n:rps:unum a `@u`(abs:si (need (toi:rps:unum b)))))
+          %mod  |=([a=@ b=@] (unum-mod %5 a b))
+          %pow  |=([a=@ b=@] (unum-pow %5 a b))
           %gth  |=([a=@ b=@] ?:((gth:rps:unum a b) one:rps:unum zero:rps:unum))
           %gte  |=([a=@ b=@] ?:((gte:rps:unum a b) one:rps:unum zero:rps:unum))
           %lth  |=([a=@ b=@] ?:((lth:rps:unum a b) one:rps:unum zero:rps:unum))
@@ -1271,8 +1337,8 @@
           %sub  sub:rpd:unum
           %mul  mul:rpd:unum
           %div  div:rpd:unum
-          %mod  |=([a=@ b=@] (sub:rpd:unum a (mul:rpd:unum b (san:rpd:unum (need (toi:rpd:unum (div:rpd:unum a b)))))))
-          %pow  |=([a=@ b=@] (pow-n:rpd:unum a `@u`(abs:si (need (toi:rpd:unum b)))))
+          %mod  |=([a=@ b=@] (unum-mod %6 a b))
+          %pow  |=([a=@ b=@] (unum-pow %6 a b))
           %gth  |=([a=@ b=@] ?:((gth:rpd:unum a b) one:rpd:unum zero:rpd:unum))
           %gte  |=([a=@ b=@] ?:((gte:rpd:unum a b) one:rpd:unum zero:rpd:unum))
           %lth  |=([a=@ b=@] ?:((lth:rpd:unum a b) one:rpd:unum zero:rpd:unum))

--- a/lagoon/desk/lib/lagoon.hoon
+++ b/lagoon/desk/lib/lagoon.hoon
@@ -710,6 +710,9 @@
     |=  a=ray
     ^-  ray
     ?>  (check a)
+    ::  %unum: exact quire sum (single rounding), see +unum-sum.
+    ?:  ?=(%unum kind.meta.a)
+      (scalar-to-ray meta.a (unum-sum bloq.meta.a (ravel a)))
     %+  scalar-to-ray  meta.a
     (reel (ravel a) |=([b=@ c=@] ((fun-scalar meta.a %add) b c)))
   ::
@@ -842,6 +845,10 @@
     |=  [a=ray b=ray]
     ^-  ray
     ?>  =(shape.meta.a shape.meta.b)
+    ::  %unum: fuse the multiply-accumulate in the quire (single rounding)
+    ::  rather than rounding each product and each partial sum.
+    ?:  ?=(%unum kind.meta.a)
+      (scalar-to-ray meta.a (unum-fdp bloq.meta.a (ravel a) (ravel b)))
     (cumsum (mul a b))
   ::
   ++  mmul
@@ -861,6 +868,8 @@
         =(2 (lent shape.meta.a))
         =((snag 1 shape.meta.a) (snag 0 shape.meta.b))
     ==
+    ::  %unum: accumulate each output cell exactly in the quire, see +mmul-unum.
+    ?:  ?=(%unum kind.meta.a)  (mmul-unum a b)
     |-
       ?:   =(i (snag 0 shape.meta.prod))
         prod
@@ -888,6 +897,27 @@
           ==
         ==
       ==
+  ::  +mmul-unum: posit matrix multiply with quire-exact accumulation.  Each
+  ::  output cell [i j] is the fused dot product of row i of a and column j of
+  ::  b, rounded once.  Assumes the shape checks in +mmul already passed.
+  ++  mmul-unum
+    ~/  %mmul-unum
+    |=  [a=ray b=ray]
+    ^-  ray
+    =/  m   (snag 0 shape.meta.a)
+    =/  nn  (snag 1 shape.meta.b)
+    =/  kk  (snag 1 shape.meta.a)
+    =/  bl  bloq.meta.a
+    =/  prod=ray  =,(meta.a (zeros [~[m nn] bloq kind ~]))
+    =/  i  0
+    |-  ^-  ray
+    ?:  =(i m)  prod
+    =/  j  0
+    |-  ^-  ray
+    ?:  =(j nn)  ^$(i +(i), prod prod)
+    =/  av=(list @)  (turn (gulf 0 (dec kk)) |=(p=@ `@`(get-item a ~[i p])))
+    =/  bv=(list @)  (turn (gulf 0 (dec kk)) |=(p=@ `@`(get-item b ~[p j])))
+    $(j +(j), prod (set-item prod ~[i j] (unum-fdp bl av bv)))
 ::
   ++  abs
     ~/  %abs
@@ -1039,6 +1069,36 @@
     |=  [a=ray]
     ^-  ?(%.y %.n)
     ?!(=(-:(ravel (min a)) 0))
+  ::
+  ::  Quire-exact posit reductions (/lib/unum fdp).  Sums of posit products
+  ::  accumulate in the 16n-bit quire and round exactly once, so dot/mmul/
+  ::  cumsum over %unum rays are correctly-rounded rather than rounding at
+  ::  every intermediate step.  bloq selects width: 3=rpb 4=rph 5=rps 6=rpd.
+  ::
+  ++  unum-one
+    |=  =bloq
+    ^-  @
+    ?+  bloq  !!
+      %3  one:rpb:unum
+      %4  one:rph:unum
+      %5  one:rps:unum
+      %6  one:rpd:unum
+    ==
+  ::  +unum-fdp: fused dot product of two equal-length posit vectors.
+  ++  unum-fdp
+    |=  [=bloq av=(list @) bv=(list @)]
+    ^-  @
+    ?+  bloq  !!
+      %3  (fdp:rpb:unum av bv)
+      %4  (fdp:rph:unum av bv)
+      %5  (fdp:rps:unum av bv)
+      %6  (fdp:rpd:unum av bv)
+    ==
+  ::  +unum-sum: exact sum of a posit vector (fdp against a vector of ones).
+  ++  unum-sum
+    |=  [=bloq v=(list @)]
+    ^-  @
+    (unum-fdp bloq v (reap (lent v) (unum-one bloq)))
   ::
   +$  ops   $?  %add
                 %sub

--- a/lagoon/desk/sur/lagoon.hoon
+++ b/lagoon/desk/sur/lagoon.hoon
@@ -19,8 +19,8 @@
   $?  %i754           ::  IEEE 754 float
       %uint           ::  unsigned integer
       %int2           ::  2s-complement integer (/lib/twoc)
+      %unum           ::  unum/posit (/lib/unum) @rpb @rph @rps @rpd
       :: %cplx           ::  BLAS-compatible packed floats
-      :: %unum           ::  unum/posit  @ruw, @ruh, @rub
       :: %fixp           ::  fixed-precision (/lib/fixed)
   ==
 ::

--- a/lagoon/desk/tests/lib/lagoon-unum.hoon
+++ b/lagoon/desk/tests/lib/lagoon-unum.hoon
@@ -22,6 +22,16 @@
   |=  [op=$-([ray ray] ray) b=@ c=@]  ^-  @
   =/  m1=meta  [~[1 1] 4 %unum ~]
   (get-item:la (op (fill:la m1 b) (fill:la m1 c)) ~[0 0])
+::  posit32 (bloq 5, rps)
+++  bin32
+  |=  [op=$-([ray ray] ray) b=@ c=@]  ^-  @
+  =/  m1=meta  [~[1 1] 5 %unum ~]
+  (get-item:la (op (fill:la m1 b) (fill:la m1 c)) ~[0 0])
+::  posit64 (bloq 6, rpd)
+++  bin64
+  |=  [op=$-([ray ray] ray) b=@ c=@]  ^-  @
+  =/  m1=meta  [~[1 1] 6 %unum ~]
+  (get-item:la (op (fill:la m1 b) (fill:la m1 c)) ~[0 0])
 ::
 ::  arithmetic, posit8 (correctly rounded, es=2)
 ++  test-unum-arith  ^-  tang
@@ -107,5 +117,36 @@
     %+  expect-eq  !>(`@`0x62)  !>((get-item:la c ~[0 1]))   ::  22 -> 24
     %+  expect-eq  !>(`@`0x65)  !>((get-item:la c ~[1 0]))   ::  43 -> 40
     %+  expect-eq  !>(`@`0x66)  !>((get-item:la c ~[1 1]))   ::  50 -> 48
+  ==
+::  %mod truncates the quotient toward zero (C fmod): -3.5 mod 2 = -1.5
+::  (0xbc).  A round-the-quotient implementation would give +0.5 (0x38).
+++  test-unum-mod-trunc  ^-  tang
+  %+  expect-eq  !>(`@`0xbc)  !>((bin mod:la 0xb2 0x48))     ::  -3.5 mod 2 = -1.5
+::  %pow with a negative exponent yields the reciprocal: 2^-2 = 0.25 (0x30).
+++  test-unum-pow-neg  ^-  tang
+  =/  m1=meta  [~[1 1] 3 %unum ~]
+  %+  expect-eq  !>(`@`0x30)  !>(((fun-scalar:la m1 %pow) 0x48 0xb8))  ::  2^-2 = 1/4
+::  NaR / div-by-zero guards return posit nar (0x80) instead of crashing.
+++  test-unum-guards  ^-  tang
+  =/  m1=meta  [~[1 1] 3 %unum ~]
+  ;:  weld
+    %+  expect-eq  !>(`@`0x80)  !>((bin mod:la 0x52 0x0))             ::  5 mod 0 = nar
+    %+  expect-eq  !>(`@`0x80)  !>((bin mod:la 0x80 0x4c))            ::  nar mod 3 = nar
+    %+  expect-eq  !>(`@`0x80)  !>(((fun-scalar:la m1 %pow) 0x48 0x80))  ::  2^nar = nar
+  ==
+::  posit32 (bloq 5) and posit64 (bloq 6) arithmetic dispatch
+++  test-unum-posit32  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x5200.0000)  !>((bin32 add:la 0x4800.0000 0x4c00.0000))   ::  2+3=5
+    %+  expect-eq  !>(`@`0x5c00.0000)  !>((bin32 mul:la 0x4c00.0000 0x5000.0000))   ::  3*4=12
+  ==
+++  test-unum-posit64  ^-  tang
+  ;:  weld
+    %+  expect-eq
+      !>(`@`0x5200.0000.0000.0000)
+      !>((bin64 add:la 0x4800.0000.0000.0000 0x4c00.0000.0000.0000))               ::  2+3=5
+    %+  expect-eq
+      !>(`@`0x5c00.0000.0000.0000)
+      !>((bin64 mul:la 0x4c00.0000.0000.0000 0x5000.0000.0000.0000))               ::  3*4=12
   ==
 --

--- a/lagoon/desk/tests/lib/lagoon-unum.hoon
+++ b/lagoon/desk/tests/lib/lagoon-unum.hoon
@@ -75,4 +75,37 @@
     %+  expect-eq  !>(`@`0x5200)  !>((bin16 add:la 0x4800 0x4c00))   ::  2+3=5
     %+  expect-eq  !>(`@`0x5c00)  !>((bin16 mul:la 0x4c00 0x5000))   ::  3*4=12
   ==
+::  quire-exact dot product: 0.25*5 + 3*7 = 22.25, correctly rounded to
+::  posit8 0x62 (24.0).  The naive round-each-step path would give 0x61
+::  (20.0); this asserts the fused single-rounding result.
+++  test-unum-dot  ^-  tang
+  =/  m=meta  [~[1 2] 3 %unum ~]
+  =/  a=ray  (fill:la m 0x0)
+  =.  a  (set-item:la a ~[0 0] 0x30)              ::  0.25
+  =.  a  (set-item:la a ~[0 1] 0x4c)              ::  3.0
+  =/  b=ray  (fill:la m 0x0)
+  =.  b  (set-item:la b ~[0 0] 0x52)              ::  5.0
+  =.  b  (set-item:la b ~[0 1] 0x56)              ::  7.0
+  %+  expect-eq  !>(`@`0x62)  !>((get-item:la (dot:la a b) ~[0 0]))
+::  quire-exact matrix multiply: [[1 2][3 4]] x [[5 6][7 8]] = [[19 22][43 50]],
+::  each cell correctly rounded in posit8 -> 0x61 0x62 / 0x65 0x66.
+++  test-unum-mmul  ^-  tang
+  =/  m=meta  [~[2 2] 3 %unum ~]
+  =/  a=ray  (fill:la m 0x0)
+  =.  a  (set-item:la a ~[0 0] 0x40)              ::  1
+  =.  a  (set-item:la a ~[0 1] 0x48)              ::  2
+  =.  a  (set-item:la a ~[1 0] 0x4c)              ::  3
+  =.  a  (set-item:la a ~[1 1] 0x50)              ::  4
+  =/  b=ray  (fill:la m 0x0)
+  =.  b  (set-item:la b ~[0 0] 0x52)              ::  5
+  =.  b  (set-item:la b ~[0 1] 0x54)              ::  6
+  =.  b  (set-item:la b ~[1 0] 0x56)              ::  7
+  =.  b  (set-item:la b ~[1 1] 0x58)              ::  8
+  =/  c=ray  (mmul:la a b)
+  ;:  weld
+    %+  expect-eq  !>(`@`0x61)  !>((get-item:la c ~[0 0]))   ::  19 -> 20
+    %+  expect-eq  !>(`@`0x62)  !>((get-item:la c ~[0 1]))   ::  22 -> 24
+    %+  expect-eq  !>(`@`0x65)  !>((get-item:la c ~[1 0]))   ::  43 -> 40
+    %+  expect-eq  !>(`@`0x66)  !>((get-item:la c ~[1 1]))   ::  50 -> 48
+  ==
 --

--- a/lagoon/desk/tests/lib/lagoon-unum.hoon
+++ b/lagoon/desk/tests/lib/lagoon-unum.hoon
@@ -1,0 +1,78 @@
+/-  *lagoon
+/+  *test
+/+  *lagoon
+::::  /tests/lib/lagoon-unum -- posit (unum) arrays, /lib/unum
+::
+::  posit8 = bloq 3, kind %unum (rpb); posit16 = bloq 4 (rph).  Build rays
+::  with `fill`, read back with get-item.  Expected bit patterns come from
+::  the SoftPosit-cross-checked oracle in tools/posit_check.py (es=2).
+::
+::  Reference posit8 patterns: 1=0x40 2=0x48 3=0x4c 5=0x52 6=0x54 8=0x58
+::  1.5=0x44 -2=0xb8 -5=0xae 1/4=0x30; zero=0x00 (one/zero = compare values).
+::
+^|
+|%
+::  apply a binary ray op to two posit8 scalars, read the result scalar
+++  bin
+  |=  [op=$-([ray ray] ray) b=@ c=@]  ^-  @
+  =/  m1=meta  [~[1 1] 3 %unum ~]
+  (get-item:la (op (fill:la m1 b) (fill:la m1 c)) ~[0 0])
+::  same, for posit16
+++  bin16
+  |=  [op=$-([ray ray] ray) b=@ c=@]  ^-  @
+  =/  m1=meta  [~[1 1] 4 %unum ~]
+  (get-item:la (op (fill:la m1 b) (fill:la m1 c)) ~[0 0])
+::
+::  arithmetic, posit8 (correctly rounded, es=2)
+++  test-unum-arith  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x52)  !>((bin add:la 0x48 0x4c))    ::  2+3=5
+    %+  expect-eq  !>(`@`0xb8)  !>((bin sub:la 0x4c 0x52))    ::  3-5=-2
+    %+  expect-eq  !>(`@`0x54)  !>((bin mul:la 0x48 0x4c))    ::  2*3=6
+    %+  expect-eq  !>(`@`0x44)  !>((bin div:la 0x4c 0x48))    ::  3/2=1.5
+    %+  expect-eq  !>(`@`0x30)  !>((bin div:la 0x40 0x50))    ::  1/4
+  ==
+::  mod (a - b*trunc(a/b)) via the ray op; pow via fun-scalar directly
+::  (lagoon exposes no ray-level binary pow, only fun-scalar's %pow).
+++  test-unum-mod-pow  ^-  tang
+  =/  m1=meta  [~[1 1] 3 %unum ~]
+  ;:  weld
+    %+  expect-eq  !>(`@`0x40)  !>((bin mod:la 0x56 0x4c))            ::  7 mod 3 = 1
+    %+  expect-eq  !>(`@`0x58)  !>(((fun-scalar:la m1 %pow) 0x48 0x4c))  ::  2^3 = 8
+  ==
+::  comparisons return posit 1 (one=0x40) / 0 (zero=0x00)
+++  test-unum-compare  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x40)  !>((bin lth:la 0xae 0x40))    ::  -5 < 1 -> 1
+    %+  expect-eq  !>(`@`0x0)  !>((bin gth:la 0xae 0x40))    ::  -5 > 1 -> 0
+    %+  expect-eq  !>(`@`0x40)  !>((bin gth:la 0x40 0xae))    ::  1 > -5 -> 1
+    %+  expect-eq  !>(`@`0x40)  !>((bin gte:la 0x48 0x48))    ::  2 >= 2 -> 1
+    %+  expect-eq  !>(`@`0x40)  !>((bin equ:la 0x48 0x48))    ::  2 == 2 -> 1
+    %+  expect-eq  !>(`@`0x0)  !>((bin equ:la 0x48 0x4c))    ::  2 == 3 -> 0
+  ==
+::  unary abs over a filled ray
+++  test-unum-abs  ^-  tang
+  =/  m1=meta  [~[1 1] 3 %unum ~]
+  ;:  weld
+    %+  expect-eq  !>(`@`0x52)  !>((get-item:la (abs:la (fill:la m1 0xae)) ~[0 0]))
+    %+  expect-eq  !>(`@`0x52)  !>((get-item:la (abs:la (fill:la m1 0x52)) ~[0 0]))
+  ==
+::  ones builder uses the %unum constant one (0x40)
+++  test-unum-ones  ^-  tang
+  =/  m=meta  [~[2 2] 3 %unum ~]
+  %+  expect-eq  !>(`@`0x40)  !>((get-item:la (ones:la m) ~[0 0]))
+::  cumsum reduction over a 1x4 posit8 ray [2 3 -5 5] = 5
+++  test-unum-cumsum  ^-  tang
+  =/  r=ray  (fill:la [~[1 4] 3 %unum ~] 0x0)
+  =.  r  (set-item:la r ~[0 0] 0x48)              ::  2
+  =.  r  (set-item:la r ~[0 1] 0x4c)              ::  3
+  =.  r  (set-item:la r ~[0 2] 0xae)              ::  -5
+  =.  r  (set-item:la r ~[0 3] 0x52)              ::  5
+  %+  expect-eq  !>(`@`0x52)  !>((get-item:la (cumsum:la r) ~[0 0]))
+::  posit16 arithmetic (bloq 4, rph)
+++  test-unum-posit16  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x5200)  !>((bin16 add:la 0x4800 0x4c00))   ::  2+3=5
+    %+  expect-eq  !>(`@`0x5c00)  !>((bin16 mul:la 0x4c00 0x5000))   ::  3*4=12
+  ==
+--


### PR DESCRIPTION
Integrates posits (`/lib/unum`, 2022 Posit Standard, es=2) into Lagoon's
n-dimensional array kinds as `%unum`, reusing the `%int2` integration pattern.

`bloq` selects width: 3=`@rpb` 4=`@rph` 5=`@rps` 6=`@rpd` (posit8/16/32/64).

## Commit 1 — element-wise dispatch

- **`sur/lagoon`**: `%unum` enabled in the `kind` union.
- **`fun-scalar`**: `add`/`sub`/`mul`/`div` correctly rounded per width;
  `%mod` = `a - b·trunc(a/b)`; `%pow` via `pow-n` (exponent = non-negative
  integer from `toi`, magnitude cast to `@u`); comparisons return posit
  `one`/`zero` to match the value convention used by the other kinds.
- **`trans-scalar`**: `%abs` per width.
- **`get-term`** (prints raw posit aura), **`eye`/`ones`** constant `one`,
  **`scale`** (raw posit bit-pattern pack, like `%int2`).

## Commit 2 — quire-exact reductions

Sums of posit products accumulate in the 16n-bit **quire** and round
exactly once (fused), instead of rounding at every intermediate step —
the property that makes posits beat floats for linear algebra.

- `unum-fdp` / `unum-sum` / `unum-one`: width-dispatched helpers over
  `/lib/unum`'s `fdp`.
- `dot` (%unum): `fdp(ravel a, ravel b)` — single rounding.
- `cumsum` (%unum, also feeds `trace`): exact quire sum.
- `mmul` (%unum): `+mmul-unum` computes each output cell as the fused dot
  product of a row and column, rounded once.
- Other kinds keep the existing round-each-step path (guarded by
  `?=(%unum kind)`); `lagoon-int2` reductions still pass.

## Tests — `tests/lib/lagoon-unum` (9, all pass on ~hex)

arith, mod/pow, comparisons, abs, `ones`, `cumsum`, posit16, plus:
- `test-unum-dot`: `0.25*5 + 3*7 = 22.25` → fused posit8 `0x62` (24.0,
  correctly rounded); the naive round-each-step path would give `0x61`
  (20.0).
- `test-unum-mmul`: `[[1 2][3 4]]·[[5 6][7 8]]` checked cell-by-cell.

Expected bit patterns come from the SoftPosit-cross-checked oracle in
`libmath/tools/posit_check.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)