### PR TITLE
/lib/fixed: round out scalar API (abs, comparisons, mod, constructors)

### DIFF
--- a/libmath/desk/lib/fixed.hoon
+++ b/libmath/desk/lib/fixed.hoon
@@ -79,6 +79,62 @@
   =/  num  (new:si (syn:si sx) (lsh [0 b.xprec] (abs:si sx)))
   =/  qa   (fra:si num (to-s y yprec))
   [(s-to-twoc:(ng xprec) qa) xprec]
+::    +mod: [@ prec @ prec] -> @
+::
+::  Signed remainder a - b*trunc(a/b), keeping the input precision.  The sign
+::  follows the dividend (truncated division), via /lib/twoc's +rem.  Both
+::  operands share precision, so the 2^b scale cancels in the remainder.
+::    Examples
+::      > (mod 0x380 [8 8] 0x200 [8 8])   :: 3.5 mod 2.0
+::      0x180                             :: 1.5
+::  Source
+++  mod
+  |=  [x=@ xprec=prec y=@ yprec=prec]
+  ?>  =(xprec yprec)
+  (rem:(ng xprec) x y)
+::    +abs: [@ prec] -> @
+::
+::  Absolute value at the number's own width (abs of the most-negative value
+::  wraps back to itself, per two's-complement).
+::    Examples
+::      > (abs (neg 0x180 [8 8]) [8 8])   :: |-1.5|
+::      0x180
+::  Source
+++  abs
+  |=  [x=@ =prec]
+  ^-  @
+  (abs:(ng prec) x)
+::    +gth/+gte/+lth/+lte/+equ/+neq: [@ prec @ prec] -> ?
+::
+::  Signed comparisons of two equal-precision fixed-point numbers.  Because
+::  both are stored at the same 2^b scale, comparing the two's-complement
+::  values (via /lib/twoc) is order-preserving on the represented reals.
+::  +equ is bit equality (two's-complement has no negative zero).
+::  Source
+++  gth
+  |=  [x=@ xprec=prec y=@ yprec=prec]
+  ?>  =(xprec yprec)
+  (gth:(ng xprec) x y)
+++  gte
+  |=  [x=@ xprec=prec y=@ yprec=prec]
+  ?>  =(xprec yprec)
+  (gte:(ng xprec) x y)
+++  lth
+  |=  [x=@ xprec=prec y=@ yprec=prec]
+  ?>  =(xprec yprec)
+  (lth:(ng xprec) x y)
+++  lte
+  |=  [x=@ xprec=prec y=@ yprec=prec]
+  ?>  =(xprec yprec)
+  (lte:(ng xprec) x y)
+++  equ
+  |=  [x=@ xprec=prec y=@ yprec=prec]
+  ?>  =(xprec yprec)
+  .=(x y)
+++  neq
+  |=  [x=@ xprec=prec y=@ yprec=prec]
+  ?>  =(xprec yprec)
+  !.=(x y)
 ::    +to-s: [@ prec] -> @s
 ::
 ::  Decode a fixed-point bit pattern to a hoon signed integer (the stored
@@ -88,6 +144,51 @@
   |=  [x=@ =prec]
   ^-  @s
   (twoc-to-s:(ng prec) x)
+::    +from-s: [@s prec] -> @
+::
+::  Encode a (whole) signed integer as a fixed-point number at the given
+::  precision: stored value = n * 2^b.  Out-of-range n crashes (s-to-twoc).
+::    Examples
+::      > (from-s --3 [8 8])   :: 3.0
+::      0x300
+::      > (from-s -2 [8 8])    :: -2.0
+::      0x1.fe00
+::  Source
+++  from-s
+  |=  [n=@s =prec]
+  ^-  @
+  (s-to-twoc:(ng prec) (new:si (syn:si n) (lsh [0 b.prec] (abs:si n))))
+::    +from-rs: [@rs prec] -> @
+::
+::  Quantize a single-precision IEEE float to fixed-point, rounding the
+::  scaled value f * 2^b to the nearest integer (ties to even).  Out-of-range
+::  results wrap (s-to-twoc).  Use this to construct fractional constants.
+::    Examples
+::      > (from-rs .1.5 [8 8])
+::      0x180
+::  Source
+++  from-rs
+  |=  [f=@rs =prec]
+  ^-  @
+  =/  i=@s  (need (~(toi rs %n) (~(mul rs %n) f (~(sun rs %n) (bex b.prec)))))
+  (s-to-twoc:(ng prec) i)
+::    +to-rs: [@ prec] -> @rs
+::
+::  Decode a fixed-point number to a single-precision IEEE float: value =
+::  stored / 2^b.  Rounded to nearest (ties to even) where not exact.
+::    Examples
+::      > (to-rs 0x180 [8 8])
+::      .1.5
+::  Source
+++  to-rs
+  |=  [x=@ =prec]
+  ^-  @rs
+  =/  s=@s  (to-s x prec)
+  =/  fs=@rs
+    ?:  (syn:si s)
+      (~(sun rs %n) (abs:si s))
+    (~(mul rs %n) .-1 (~(sun rs %n) (abs:si s)))
+  (~(div rs %n) fs (~(sun rs %n) (bex b.prec)))
 ::    +neg: [@ prec] -> @
 ::
 ::  Two's-complement negation of a fixed-point number at its own width.
@@ -105,13 +206,13 @@
 ::  Source
 ++  hi
   |=  [x=@ =prec n=@]
-  ?>  (lte n (wid prec))
+  ?>  (^lte n (wid prec))
   (rsh [0 (^sub (wid prec) n)] x)
 ::    +lo: [@ prec @] -> @   (low n bits)
 ::  Source
 ++  lo
   |=  [x=@ =prec n=@]
-  ?>  (lte n (wid prec))
+  ?>  (^lte n (wid prec))
   (dis x (dec (bex n)))
 ::    +scale: [@ prec prec] -> @
 ::
@@ -131,7 +232,7 @@
   =/  sx  (to-s x xprec)
   =/  sg  (syn:si sx)
   =/  mg  (abs:si sx)
-  =/  mg2  ?:  (gth b.yprec b.xprec)
+  =/  mg2  ?:  (^gth b.yprec b.xprec)
              (lsh [0 (^sub b.yprec b.xprec)] mg)
            (rsh [0 (^sub b.xprec b.yprec)] mg)
   (s-to-twoc:(ng yprec) (new:si sg mg2))

--- a/libmath/desk/tests/lib/fixed.hoon
+++ b/libmath/desk/tests/lib/fixed.hoon
@@ -63,4 +63,47 @@
   =/  q  (div:fixed 0x300 q88 0x200 q88)        ::  3.0/2.0 = 1.5 in q8.8
   =/  back  (mul:fixed -.q q88 0x200 q88)       ::  1.5*2.0 = 3.0 in q17.16
   %+  expect-eq  !>(`@`0x3.0000)  !>(-.back)
+::
+++  test-abs  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x180)  !>((abs:fixed n1-5 q88))     ::  |-1.5| = 1.5
+    %+  expect-eq  !>(`@`0x180)  !>((abs:fixed 0x180 q88))    ::  |1.5|  = 1.5
+  ==
+::
+++  test-mod  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x180)     !>((mod:fixed 0x380 q88 0x200 q88))  ::  3.5 mod 2 = 1.5
+    %+  expect-eq  !>(`@`0x1.fe80)  !>((mod:fixed (neg:fixed 0x380 q88) q88 0x200 q88))  ::  -3.5 mod 2 = -1.5
+  ==
+::
+::  comparisons (signed, equal precision) return loobeans
+++  test-compare  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`?`%.y)  !>((gth:fixed 0x180 q88 0x100 q88))  ::  1.5 > 1.0
+    %+  expect-eq  !>(`?`%.n)  !>((gth:fixed n1-5 q88 0x100 q88))   ::  -1.5 > 1.0 -> no
+    %+  expect-eq  !>(`?`%.y)  !>((lth:fixed n1-5 q88 0x100 q88))   ::  -1.5 < 1.0
+    %+  expect-eq  !>(`?`%.y)  !>((gte:fixed 0x100 q88 0x100 q88))  ::  1.0 >= 1.0
+    %+  expect-eq  !>(`?`%.y)  !>((lte:fixed 0x100 q88 0x100 q88))  ::  1.0 <= 1.0
+    %+  expect-eq  !>(`?`%.y)  !>((equ:fixed 0x100 q88 0x100 q88))  ::  1.0 == 1.0
+    %+  expect-eq  !>(`?`%.n)  !>((equ:fixed 0x100 q88 0x180 q88))  ::  1.0 == 1.5 -> no
+    %+  expect-eq  !>(`?`%.y)  !>((neq:fixed 0x100 q88 0x180 q88))  ::  1.0 != 1.5
+  ==
+::
+::  constructors: integer and float -> fixed
+++  test-from-s  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x300)     !>((from-s:fixed --3 q88))   ::  3.0
+    %+  expect-eq  !>(`@`0x1.fe00)  !>((from-s:fixed -2 q88))    ::  -2.0
+    %+  expect-eq  !>(`@`0x0)       !>((from-s:fixed --0 q88))   ::  0
+  ==
+::
+::  float bridge: from-rs / to-rs (1.5, -1.5, 2.25 are exact in both)
+++  test-rs-bridge  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x180)     !>((from-rs:fixed .1.5 q88))    ::  1.5
+    %+  expect-eq  !>(`@`0x1.fdc0)  !>((from-rs:fixed .-2.25 q88))  ::  -2.25
+    %+  expect-eq  !>(`@rs`.1.5)    !>((to-rs:fixed 0x180 q88))     ::  1.5
+    %+  expect-eq  !>(`@rs`.-1.5)   !>((to-rs:fixed n1-5 q88))      ::  -1.5
+    %+  expect-eq  !>(`@`0x180)     !>((from-rs:fixed (to-rs:fixed 0x180 q88) q88))  ::  round-trip
+  ==
 --


### PR DESCRIPTION
Phase A of the fixed-point buildout — completes the `/lib/fixed` scalar API
so it's usable beyond raw hex and ready for Lagoon `%fixp` integration (Phase B,
to follow).

All new arms delegate to the width-keyed `+twid` door of `/lib/twoc` already
used by `add`/`sub`/`mul`/`div`, keeping sign handling single-sourced.

## New arms
- **`abs`**, **`mod`** (signed remainder, sign of dividend, via twid `+rem`).
- **`gth`/`gte`/`lth`/`lte`/`equ`/`neq`** — signed comparisons at equal
  precision, returning loobeans. `equ` is bit equality (two's-complement has
  no negative zero).
- **`from-s`** — encode a whole signed integer (`n * 2^b`).
- **`from-rs` / `to-rs`** — single-precision IEEE float bridge (round to
  nearest), the first way to construct/read fractional values without raw hex.

## Note
Escaped the internal `gth`/`lte` uses in `scale`/`hi`/`lo` to `^gth`/`^lte`
so the new same-named arms don't shadow the standard ones (same
`/lib/twoc`-face shadowing family that bit the earlier rebuild).

## Tests
`/tests/lib/fixed` grows from 7 to 12 arms (abs, mod incl. negative,
comparisons, from-s, rs round-trip). All pass on `~hex`. Expected values are
hand-derived and consistent with the existing `fractions`/`spfpm` oracle;
extending `tools/fixed_check.py` to the new ops is a cheap optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)