### PR TITLE
Wire %fixp (fixed-point) arrays into Lagoon

### DIFF
--- a/lagoon/desk/lib/lagoon.hoon
+++ b/lagoon/desk/lib/lagoon.hoon
@@ -1,5 +1,5 @@
 /-  lagoon
-/+  twoc, unum, complex
+/+  twoc, unum, complex, fixed
 =+  lagoon
 ::                                                    ::
 ::::                    ++la                          ::  (2v) vector/matrix ops
@@ -86,6 +86,9 @@
         %6  %cs
         %5  %ch
       ==
+        %fixp
+      ::  no fixed-point printer; render the raw stored bits as hex.
+      %ux
     ==
   ::
   ++  squeeze  |*(a=* `(list _a)`~[a])
@@ -450,6 +453,9 @@
       ::  and make the caller pick (abs for modulus).  Into-complex TODO.
         %cplx
       ~|('lagoon: change out of %cplx is lossy; use abs or an explicit re/im' !!)
+      ::  %fixp conversion not yet wired; use /lib/fixed's to-rs/from-rs.
+        %fixp
+      ~|('lagoon: change/convert not yet implemented for %fixp' !!)
     ==
   ::
   ::  Builders
@@ -499,6 +505,8 @@
         %7  ~(one cd:complex rnd)
         %6  ~(one cs:complex rnd)
       ==
+      ::  fixed-point 1.0 = 2^b, with b the fractional bits from meta.tail.
+        %fixp  (bex +:;;([a=@ b=@] tail.meta))
     ==
   ::    Zeroes
   ++  zeros
@@ -537,6 +545,8 @@
           %7  ~(one cd:complex rnd)
           %6  ~(one cs:complex rnd)
         ==
+        ::  fixed-point 1.0 = 2^b (b = fractional bits from meta.tail).
+          %fixp  (bex +:;;([a=@ b=@] tail.meta))
       ==
     (fill meta one)
   ::  Produce a 1-dimensional index array.
@@ -689,6 +699,10 @@
       ::
         %cplx
       ::  data is already a packed complex bit pattern; pack it raw.
+      (spac [meta `@ux`data])
+      ::
+        %fixp
+      ::  data is already a fixed-point bit pattern; pack it raw.
       (spac [meta `@ux`data])
       ::
         %i754
@@ -885,6 +899,9 @@
     ::  rather than rounding each product and each partial sum.
     ?:  ?=(%unum kind.meta.a)
       (scalar-to-ray meta.a (unum-fdp bloq.meta.a (ravel a) (ravel b)))
+    ::  %fixp: accumulate the integer products exactly, rescale once.
+    ?:  ?=(%fixp kind.meta.a)
+      (scalar-to-ray meta.a (fixp-fdp ;;([a=@ b=@] tail.meta.a) (ravel a) (ravel b)))
     (cumsum (mul a b))
   ::  +dotc: Hermitian (conjugated) dot product, Sum conj(a_i)*b_i.  This is
   ::  the inner product whose norm <a,a> = Sum |a_i|^2 is real and nonnegative
@@ -916,6 +933,8 @@
     ==
     ::  %unum: accumulate each output cell exactly in the quire, see +mmul-unum.
     ?:  ?=(%unum kind.meta.a)  (mmul-unum a b)
+    ::  %fixp: accumulate each output cell's integer products exactly.
+    ?:  ?=(%fixp kind.meta.a)  (mmul-fixp a b)
     |-
       ?:   =(i (snag 0 shape.meta.prod))
         prod
@@ -964,6 +983,27 @@
     =/  av=(list @)  (turn (gulf 0 (dec kk)) |=(p=@ `@`(get-item a ~[i p])))
     =/  bv=(list @)  (turn (gulf 0 (dec kk)) |=(p=@ `@`(get-item b ~[p j])))
     $(j +(j), prod (set-item prod ~[i j] (unum-fdp bl av bv)))
+  ::  +mmul-fixp: fixed-point matrix multiply, each cell an exact integer
+  ::  dot product rescaled once (see +fixp-fdp), preserving the array
+  ::  precision (meta.tail).  Assumes +mmul's shape checks already passed.
+  ++  mmul-fixp
+    ~/  %mmul-fixp
+    |=  [a=ray b=ray]
+    ^-  ray
+    =/  prc  ;;([a=@ b=@] tail.meta.a)
+    =/  m   (snag 0 shape.meta.a)
+    =/  nn  (snag 1 shape.meta.b)
+    =/  kk  (snag 1 shape.meta.a)
+    =/  prod=ray  =,(meta.a (zeros [~[m nn] bloq kind tail]))
+    =/  i  0
+    |-  ^-  ray
+    ?:  =(i m)  prod
+    =/  j  0
+    |-  ^-  ray
+    ?:  =(j nn)  ^$(i +(i), prod prod)
+    =/  av=(list @)  (turn (gulf 0 (dec kk)) |=(p=@ `@`(get-item a ~[i p])))
+    =/  bv=(list @)  (turn (gulf 0 (dec kk)) |=(p=@ `@`(get-item b ~[p j])))
+    $(j +(j), prod (set-item prod ~[i j] (fixp-fdp prc av bv)))
 ::
   ++  abs
     ~/  %abs
@@ -1152,6 +1192,24 @@
     |=  [=bloq v=(list @)]
     ^-  @
     (unum-fdp bloq v (reap (lent v) (unum-one bloq)))
+  ::  +fixp-fdp: exact fixed-point dot product at precision [a b].  Decode each
+  ::  operand to its stored signed integer, accumulate the integer products
+  ::  exactly (no per-product truncation), then rescale by 2^b once and
+  ::  re-encode at the element width N = a+b+1.
+  ++  fixp-fdp
+    |=  [prc=[a=@ b=@] av=(list @) bv=(list @)]
+    ^-  @
+    =/  sm=@s
+      =|  sm=@s
+      |-  ^-  @s
+      ?~  av  sm
+      ?~  bv  sm
+      %=  $
+        av  t.av
+        bv  t.bv
+        sm  (sum:si sm (pro:si (to-s:fixed i.av prc) (to-s:fixed i.bv prc)))
+      ==
+    (s-to-twoc:(ng:fixed prc) (fra:si sm (sun:si (bex b.prc))))
   ::  +unum-mod: posit remainder a - b*trunc(a/b), the quotient truncated
   ::  TOWARD ZERO (C fmod / remainder-with-sign-of-dividend).  Returns nar on
   ::  a NaR operand or division by zero (b = posit 0) rather than crashing.
@@ -1430,6 +1488,29 @@
           %lte  ord
         ==
       ==  :: bloq cplx
+      ::
+        %fixp
+      ::  fixed-point Q a.b (/lib/fixed), prec [a b] from meta.tail, element
+      ::  width N = 2^bloq.  add/sub/mod and comparisons need only the width
+      ::  and reuse /lib/twoc (identical to %int2 on the stored integer);
+      ::  mul/div rescale by 2^b through /lib/fixed.  Comparisons return the
+      ::  fixed value 1.0 (= 2^b) for true, 0.0 for false.  Divide-by-zero
+      ::  crashes (fixed-point has no NaN).
+      =/  prc  ;;([a=@ b=@] tail)
+      =/  one  (bex b.prc)
+      ?+  fun  !!
+        %add  ~(add twoc:twoc bloq)
+        %sub  ~(sub twoc:twoc bloq)
+        %mul  |=([x=@ y=@] =/(p (mul:fixed x prc y prc) (scale:fixed -.p +.p prc)))
+        %div  |=([x=@ y=@] -:(div:fixed x prc y prc))
+        %mod  ~(rem twoc:twoc bloq)
+        %gth  |=([x=@ y=@] ?:((~(gth twoc:twoc bloq) x y) one 0x0))
+        %gte  |=([x=@ y=@] ?:((~(gte twoc:twoc bloq) x y) one 0x0))
+        %lth  |=([x=@ y=@] ?:((~(lth twoc:twoc bloq) x y) one 0x0))
+        %lte  |=([x=@ y=@] ?:((~(lte twoc:twoc bloq) x y) one 0x0))
+        %equ  |=([x=@ y=@] ?:(.=(x y) one 0x0))
+        %neq  |=([x=@ y=@] ?:(.=(x y) 0x0 one))
+      ==
     ==  :: kind
   ::
   ++  trans-scalar
@@ -1510,6 +1591,11 @@
           %abs   ~(abs cs:complex rnd)
           %conj  ~(conj cs:complex rnd)
         ==
+      ==
+      ::  fixed-point abs is two's-complement abs at the element width.
+        %fixp
+      ?+  fun  !!
+        %abs  ~(abs twoc:twoc bloq)
       ==
     ==
   ::

--- a/lagoon/desk/sur/lagoon.hoon
+++ b/lagoon/desk/sur/lagoon.hoon
@@ -21,7 +21,7 @@
       %int2           ::  2s-complement integer (/lib/twoc)
       %unum           ::  unum/posit (/lib/unum) @rpb @rph @rps @rpd
       %cplx           ::  complex (/lib/complex) @cs/@cd; bloq = total width
-      :: %fixp           ::  fixed-precision (/lib/fixed)
+      %fixp           ::  fixed-point Q a.b (/lib/fixed); prec [a b] in meta.tail
   ==
 ::
 +$  baum              ::  $baum:  ndray with metadata

--- a/lagoon/desk/tests/lib/lagoon-fixp.hoon
+++ b/lagoon/desk/tests/lib/lagoon-fixp.hoon
@@ -1,0 +1,92 @@
+/-  *lagoon
+/+  *test
+/+  *lagoon
+::::  /tests/lib/lagoon-fixp -- fixed-point (Q a.b) arrays, /lib/fixed
+::
+::  Element width is a power of two: a+b+1 = 2^bloq.  Here q3.4 (a=3 b=4,
+::  N=8, bloq 3); the precision [a b] is carried in meta.tail.  Build rays
+::  with `fill`, read back with get-item.
+::
+::  q3.4 scale = 2^4 = 16.  1.0=0x10 1.5=0x18 2.0=0x20 0.5=0x8 0.25=0x4
+::  0.75=0x0c 3.0=0x30 4.0=0x40 3.5=0x38; -1.0=0xf0 -1.5=0xe8 -2.0=0xe0.
+::  one (1.0) = 0x10.
+::
+^|
+|%
+::  apply a binary ray op to two q3.4 scalars, read the result scalar
+++  bin
+  |=  [op=$-([ray ray] ray) b=@ c=@]  ^-  @
+  =/  m1=meta  [~[1 1] 3 %fixp [3 4]]
+  (get-item:la (op (fill:la m1 b) (fill:la m1 c)) ~[0 0])
+::
+::  element-wise arithmetic (signed, rescaled for mul/div)
+++  test-fixp-arith  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x18)  !>((bin add:la 0x10 0x8))   ::  1.0+0.5=1.5
+    %+  expect-eq  !>(`@`0xf0)  !>((bin sub:la 0x10 0x20))   ::  1.0-2.0=-1.0
+    %+  expect-eq  !>(`@`0x30)  !>((bin mul:la 0x18 0x20))   ::  1.5*2.0=3.0
+    %+  expect-eq  !>(`@`0x4)  !>((bin mul:la 0x8 0x8))   ::  0.5*0.5=0.25
+    %+  expect-eq  !>(`@`0x18)  !>((bin div:la 0x30 0x20))   ::  3.0/2.0=1.5
+    %+  expect-eq  !>(`@`0x18)  !>((bin mod:la 0x38 0x20))   ::  3.5 mod 2.0=1.5
+  ==
+::  comparisons return fixed 1.0 (one=0x10) / 0.0 (0x0)
+++  test-fixp-compare  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x10)  !>((bin gth:la 0x18 0x10))   ::  1.5 > 1.0 -> 1
+    %+  expect-eq  !>(`@`0x0)   !>((bin gth:la 0x8 0x10))   ::  0.5 > 1.0 -> 0
+    %+  expect-eq  !>(`@`0x10)  !>((bin lth:la 0xe8 0x10))   ::  -1.5 < 1.0 -> 1
+    %+  expect-eq  !>(`@`0x10)  !>((bin gte:la 0x10 0x10))   ::  1.0 >= 1.0 -> 1
+    %+  expect-eq  !>(`@`0x10)  !>((bin equ:la 0x10 0x10))   ::  1.0 == 1.0 -> 1
+    %+  expect-eq  !>(`@`0x0)   !>((bin equ:la 0x10 0x18))   ::  1.0 == 1.5 -> 0
+  ==
+::  unary abs over a filled ray
+++  test-fixp-abs  ^-  tang
+  =/  m1=meta  [~[1 1] 3 %fixp [3 4]]
+  ;:  weld
+    %+  expect-eq  !>(`@`0x18)  !>((get-item:la (abs:la (fill:la m1 0xe8)) ~[0 0]))  ::  |-1.5|
+    %+  expect-eq  !>(`@`0x18)  !>((get-item:la (abs:la (fill:la m1 0x18)) ~[0 0]))  ::  |1.5|
+  ==
+::  ones builder uses the %fixp constant 1.0 = 2^b = 0x10
+++  test-fixp-ones  ^-  tang
+  =/  m=meta  [~[2 2] 3 %fixp [3 4]]
+  %+  expect-eq  !>(`@`0x10)  !>((get-item:la (ones:la m) ~[0 0]))
+::  cumsum over [0.5 1.0 1.5 -1.0] = 2.0 (exact integer sum)
+++  test-fixp-cumsum  ^-  tang
+  =/  r=ray  (fill:la [~[1 4] 3 %fixp [3 4]] 0x0)
+  =.  r  (set-item:la r ~[0 0] 0x8)              ::  0.5
+  =.  r  (set-item:la r ~[0 1] 0x10)              ::  1.0
+  =.  r  (set-item:la r ~[0 2] 0x18)              ::  1.5
+  =.  r  (set-item:la r ~[0 3] 0xf0)              ::  -1.0
+  %+  expect-eq  !>(`@`0x20)  !>((get-item:la (cumsum:la r) ~[0 0]))
+::  exact dot product: 0.5*2.0 + 1.5*2.0 = 4.0 (0x40)
+++  test-fixp-dot  ^-  tang
+  =/  m=meta  [~[1 2] 3 %fixp [3 4]]
+  =/  a=ray  (fill:la m 0x0)
+  =.  a  (set-item:la a ~[0 0] 0x8)              ::  0.5
+  =.  a  (set-item:la a ~[0 1] 0x18)              ::  1.5
+  =/  b=ray  (fill:la m 0x0)
+  =.  b  (set-item:la b ~[0 0] 0x20)              ::  2.0
+  =.  b  (set-item:la b ~[0 1] 0x20)              ::  2.0
+  %+  expect-eq  !>(`@`0x40)  !>((get-item:la (dot:la a b) ~[0 0]))
+::  exact matrix multiply: [[1.0 0.5][0.0 2.0]] x [[2.0 0.0][0.0 0.5]]
+::  = [[2.0 0.25][0.0 1.0]] -> 0x20 0x4 / 0x0 0x10
+++  test-fixp-mmul  ^-  tang
+  =/  m=meta  [~[2 2] 3 %fixp [3 4]]
+  =/  a=ray  (fill:la m 0x0)
+  =.  a  (set-item:la a ~[0 0] 0x10)              ::  1.0
+  =.  a  (set-item:la a ~[0 1] 0x8)              ::  0.5
+  =.  a  (set-item:la a ~[1 0] 0x0)              ::  0.0
+  =.  a  (set-item:la a ~[1 1] 0x20)              ::  2.0
+  =/  b=ray  (fill:la m 0x0)
+  =.  b  (set-item:la b ~[0 0] 0x20)              ::  2.0
+  =.  b  (set-item:la b ~[0 1] 0x0)              ::  0.0
+  =.  b  (set-item:la b ~[1 0] 0x0)              ::  0.0
+  =.  b  (set-item:la b ~[1 1] 0x8)              ::  0.5
+  =/  c=ray  (mmul:la a b)
+  ;:  weld
+    %+  expect-eq  !>(`@`0x20)  !>((get-item:la c ~[0 0]))   ::  2.0
+    %+  expect-eq  !>(`@`0x4)  !>((get-item:la c ~[0 1]))   ::  0.25
+    %+  expect-eq  !>(`@`0x0)  !>((get-item:la c ~[1 0]))   ::  0.0
+    %+  expect-eq  !>(`@`0x10)  !>((get-item:la c ~[1 1]))   ::  1.0
+  ==
+--


### PR DESCRIPTION
Phase B of the fixed-point buildout — integrates `/lib/fixed` into Lagoon as
the `%fixp` array kind, element-wise plus exact reductions, mirroring the
`%int2`/`%unum` integrations.

Independent of PR #43 (Phase A scalar API): this uses only `/lib/fixed`'s
pre-existing `mul`/`div`/`scale`/`to-s`/`ng` arms.

## Representation
A fixed-point element occupies `2^bloq` bits, with `a + b + 1 = 2^bloq`
(q3.4 @ bloq3/8b, q7.8 @ bloq4/16b, q15.16 @ bloq5/32b) — the same power-of-2
tiling every other kind uses. The precision `[a b]` rides in **`meta.tail`**
(its declared "future data" slot), read via `;;([a=@ b=@] tail)`.

## What's wired
- **`sur/lagoon`**: `%fixp` enabled in the `kind` union.
- **`fun-scalar`**: `add`/`sub`/`mod` and all comparisons need only the
  element width and reuse `/lib/twoc` directly (identical to `%int2` on the
  stored integer). `mul`/`div` rescale by `2^b` through `/lib/fixed`; `mul`
  **re-quantizes back to the array precision** rather than widening (array
  elements are uniform — truncating, documented). Comparisons return the
  fixed value `1.0` (= `2^b`) / `0.0`.
- **`trans-scalar` `%abs`**: two's-complement abs at the element width.
- **`get-term`** (`%ux`, no fixed-point printer), **`eye`/`ones`** constant
  `1.0 = 2^b` from `meta.tail`, **`scale`** raw-pack, **`change`** guarded
  with a `~|` message (conversion not yet wired).
- **Reductions**: `dot`/`mmul` use a new `+fixp-fdp` that accumulates the
  integer products `Σ sx·sy` exactly, then rescales by `2^b` once — exact,
  no per-product truncation. `cumsum` needs no special path (fixed add is
  already exact modular integer add).

## Tests — `/tests/lib/lagoon-fixp` (7, all pass on ~hex)
q3.4 coverage: arithmetic, comparisons, abs, the `ones` builder, `cumsum`,
and exact `dot`/`mmul`. The `%unum` (14) and `%int2` (5) regression suites
remain green.

## Not in scope
`change`/convert for `%fixp` (use `/lib/fixed`'s `to-rs`/`from-rs`); jets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)