### PR TITLE
Phase 1: /lib/complex + wire %cplx into Lagoon

### DIFF
--- a/lagoon/desk/lib/lagoon.hoon
+++ b/lagoon/desk/lib/lagoon.hoon
@@ -1,5 +1,5 @@
 /-  lagoon
-/+  twoc, unum
+/+  twoc, unum, complex
 =+  lagoon
 ::                                                    ::
 ::::                    ++la                          ::  (2v) vector/matrix ops
@@ -76,6 +76,15 @@
         %5  %rps
         %4  %rph
         %3  %rpb
+      ==
+      ::
+        %cplx
+      ::  packed complex; render as the @c aura (no decimal printer yet).
+      ?+    bloq.meta  ~|(bloq.meta !!)
+        %8  %cq
+        %7  %cd
+        %6  %cs
+        %5  %ch
       ==
     ==
   ::
@@ -437,6 +446,10 @@
       ::  to-r*/from-r* matrix in /lib/unum for the eventual mapping.
         %unum
       ~|('lagoon: change/convert not yet implemented for %unum' !!)
+      ::  out of complex is lossy and ambiguous (real part? modulus?); refuse
+      ::  and make the caller pick (abs for modulus).  Into-complex TODO.
+        %cplx
+      ~|('lagoon: change out of %cplx is lossy; use abs or an explicit re/im' !!)
     ==
   ::
   ::  Builders
@@ -480,6 +493,12 @@
         %4  one:rph:unum
         %3  one:rpb:unum
       ==
+      ::
+        %cplx
+      ?+  bloq.meta  ~|(bloq.meta !!)
+        %7  ~(one cd:complex rnd)
+        %6  ~(one cs:complex rnd)
+      ==
     ==
   ::    Zeroes
   ++  zeros
@@ -511,6 +530,12 @@
           %5  one:rps:unum
           %4  one:rph:unum
           %3  one:rpb:unum
+        ==
+        ::
+          %cplx
+        ?+  bloq.meta  !!
+          %7  ~(one cd:complex rnd)
+          %6  ~(one cs:complex rnd)
         ==
       ==
     (fill meta one)
@@ -660,6 +685,10 @@
       ::
         %unum
       ::  data is already a posit bit pattern; pack it raw, like %int2.
+      (spac [meta `@ux`data])
+      ::
+        %cplx
+      ::  data is already a packed complex bit pattern; pack it raw.
       (spac [meta `@ux`data])
       ::
         %i754
@@ -857,6 +886,16 @@
     ?:  ?=(%unum kind.meta.a)
       (scalar-to-ray meta.a (unum-fdp bloq.meta.a (ravel a) (ravel b)))
     (cumsum (mul a b))
+  ::  +dotc: Hermitian (conjugated) dot product, Sum conj(a_i)*b_i.  This is
+  ::  the inner product whose norm <a,a> = Sum |a_i|^2 is real and nonnegative
+  ::  (what Saloon's eig/QR want).  For real kinds conj is identity, so dotc
+  ::  coincides with dot.
+  ++  dotc
+    ~/  %dotc
+    |=  [a=ray b=ray]
+    ^-  ray
+    ?>  =(shape.meta.a shape.meta.b)
+    (dot (conj a) b)
   ::
   ++  mmul
     ~/  %mmul
@@ -931,6 +970,13 @@
     |=  a=ray
     ^-  ray
     (el-wise-op a (trans-scalar bloq.meta.a kind.meta.a %abs))
+::
+  ::  +conj: elementwise complex conjugate (identity on real kinds).
+  ++  conj
+    ~/  %conj
+    |=  a=ray
+    ^-  ray
+    (el-wise-op a (trans-scalar bloq.meta.a kind.meta.a %conj))
 ::
   ++  add-scalar
     ~/  %add-scal
@@ -1176,6 +1222,7 @@
                 %equ
                 %neq
                 %abs
+                %conj
             ==
   ::
   ++  fun-scalar
@@ -1347,20 +1394,60 @@
           %neq  |=([a=@ b=@] ?:((neq:rpd:unum a b) one:rpd:unum zero:rpd:unum))
         ==
       ==  :: bloq unum
+      ::
+        %cplx
+      ::  complex (/lib/complex), bloq selects width: 6=cs (2x@rs) 7=cd (2x@rd).
+      ::  add/sub/mul/div are per-component float ops; comparisons are equ/neq
+      ::  only (complex has no total order, so gth/gte/lth/lte crash); %conj is
+      ::  unary (see +trans-scalar).  Reductions use the generic round-each-step
+      ::  path (there is no exact complex accumulator).
+      =/  ord  |=([a=@ b=@] ^-(@ ~|('lagoon: %cplx has no total order; use abs/equ' !!)))
+      ?+    `^bloq`bloq  !!
+          %6
+        ?+  fun  !!
+          %add  ~(add cs:complex rnd)
+          %sub  ~(sub cs:complex rnd)
+          %mul  ~(mul cs:complex rnd)
+          %div  ~(div cs:complex rnd)
+          %equ  |=([a=@ b=@] ?:((~(equ cs:complex rnd) a b) ~(one cs:complex rnd) `@`0))
+          %neq  |=([a=@ b=@] ?:((~(neq cs:complex rnd) a b) ~(one cs:complex rnd) `@`0))
+          %gth  ord
+          %gte  ord
+          %lth  ord
+          %lte  ord
+        ==
+          %7
+        ?+  fun  !!
+          %add  ~(add cd:complex rnd)
+          %sub  ~(sub cd:complex rnd)
+          %mul  ~(mul cd:complex rnd)
+          %div  ~(div cd:complex rnd)
+          %equ  |=([a=@ b=@] ?:((~(equ cd:complex rnd) a b) ~(one cd:complex rnd) `@`0))
+          %neq  |=([a=@ b=@] ?:((~(neq cd:complex rnd) a b) ~(one cd:complex rnd) `@`0))
+          %gth  ord
+          %gte  ord
+          %lth  ord
+          %lte  ord
+        ==
+      ==  :: bloq cplx
     ==  :: kind
   ::
   ++  trans-scalar
     |=  [=bloq =kind fun=ops]
     ^-  $-(@ @)
+    ::  %conj is the complex conjugate; for every non-complex (real) kind it
+    ::  is the identity, which is what makes +dotc reduce to +dot on reals.
     ?-    kind
         %uint
       ?+  fun  !!
-        %abs  |=(b=@ b)
+        %abs   |=(b=@ b)
+        %conj  |=(b=@ b)
       ==
       ::
         %int2
       ?+  fun  !!
-        %abs  ~(abs twoc:twoc bloq)
+        %abs   ~(abs twoc:twoc bloq)
+        %conj  |=(b=@ b)
       ==
       ::
         %i754
@@ -1368,27 +1455,61 @@
           %7
         ?+  fun  !!
           %abs  |=(b=@ ?:((~(gte rq rnd) b .~~~0) b (~(mul rq rnd) b .~~~-1)))
+          %conj  |=(b=@ b)
         ==
           %6
         ?+  fun  !!
           %abs  |=(b=@ ?:((~(gte rd rnd) b .~0) b (~(mul rd rnd) b .~-1)))
+          %conj  |=(b=@ b)
         ==
           %5
         ?+  fun  !!
           %abs  |=(b=@ ?:((~(gte rs rnd) b .0) b (~(mul rs rnd) b .-1)))
+          %conj  |=(b=@ b)
         ==
           %4
         ?+  fun  !!
           %abs  |=(b=@ ?:((~(gte rh rnd) b .~~0) b (~(mul rh rnd) b .~~-1)))
+          %conj  |=(b=@ b)
         ==
       ==
       ::
         %unum
       ?+    bloq  !!
-        %6  ?+(fun !! %abs abs:rpd:unum)
-        %5  ?+(fun !! %abs abs:rps:unum)
-        %4  ?+(fun !! %abs abs:rph:unum)
-        %3  ?+(fun !! %abs abs:rpb:unum)
+          %6
+        ?+  fun  !!
+          %abs   abs:rpd:unum
+          %conj  |=(b=@ b)
+        ==
+          %5
+        ?+  fun  !!
+          %abs   abs:rps:unum
+          %conj  |=(b=@ b)
+        ==
+          %4
+        ?+  fun  !!
+          %abs   abs:rph:unum
+          %conj  |=(b=@ b)
+        ==
+          %3
+        ?+  fun  !!
+          %abs   abs:rpb:unum
+          %conj  |=(b=@ b)
+        ==
+      ==
+      ::
+        %cplx
+      ?+    bloq  !!
+          %7
+        ?+  fun  !!
+          %abs   ~(abs cd:complex rnd)
+          %conj  ~(conj cd:complex rnd)
+        ==
+          %6
+        ?+  fun  !!
+          %abs   ~(abs cs:complex rnd)
+          %conj  ~(conj cs:complex rnd)
+        ==
       ==
     ==
   ::

--- a/lagoon/desk/sur/lagoon.hoon
+++ b/lagoon/desk/sur/lagoon.hoon
@@ -20,7 +20,7 @@
       %uint           ::  unsigned integer
       %int2           ::  2s-complement integer (/lib/twoc)
       %unum           ::  unum/posit (/lib/unum) @rpb @rph @rps @rpd
-      :: %cplx           ::  BLAS-compatible packed floats
+      %cplx           ::  complex (/lib/complex) @cs/@cd; bloq = total width
       :: %fixp           ::  fixed-precision (/lib/fixed)
   ==
 ::

--- a/lagoon/desk/tests/lib/lagoon-cplx.hoon
+++ b/lagoon/desk/tests/lib/lagoon-cplx.hoon
@@ -1,0 +1,92 @@
+/-  *lagoon
+/+  *test
+/+  *lagoon
+::::  /tests/lib/lagoon-cplx -- complex (@cs) arrays, /lib/complex
+::
+::  @cs = bloq 6 (complex-single, two @rs); element packs real low, imag high.
+::  Build rays with `fill`, read back with get-item.  Expected bit patterns
+::  from NumPy complex64.  1+2i=0x4000.0000.3f80.0000, 3+4i=0x4080.0000.4040.0000,
+::  one (1+0i)=0x3f80.0000, zero=0x0.
+::
+^|
+|%
+::  apply a binary ray op to two @cs scalars, read the result scalar
+++  bin
+  |=  [op=$-([ray ray] ray) b=@ c=@]  ^-  @
+  =/  m1=meta  [~[1 1] 6 %cplx ~]
+  (get-item:la (op (fill:la m1 b) (fill:la m1 c)) ~[0 0])
+::
+::  element-wise arithmetic (per-component IEEE single)
+++  test-cplx-arith  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x40c0.0000.4080.0000)
+      !>((bin add:la 0x4000.0000.3f80.0000 0x4080.0000.4040.0000))   ::  (1+2i)+(3+4i)=4+6i
+    %+  expect-eq  !>(`@`0xc000.0000.c000.0000)
+      !>((bin sub:la 0x4000.0000.3f80.0000 0x4080.0000.4040.0000))   ::  =-2-2i
+    %+  expect-eq  !>(`@`0x4120.0000.c0a0.0000)
+      !>((bin mul:la 0x4000.0000.3f80.0000 0x4080.0000.4040.0000))   ::  =-5+10i
+    %+  expect-eq  !>(`@`0x4000.0000)
+      !>((bin div:la 0x4000.0000.4000.0000 0x3f80.0000.3f80.0000))   ::  (2+2i)/(1+1i)=2
+  ==
+::  abs (modulus, real-valued complex) and conj
+++  test-cplx-unary  ^-  tang
+  =/  m1=meta  [~[1 1] 6 %cplx ~]
+  ;:  weld
+    %+  expect-eq  !>(`@`0x40a0.0000)            !>((get-item:la (abs:la (fill:la m1 0x4080.0000.4040.0000)) ~[0 0]))   ::  |3+4i|=5
+    %+  expect-eq  !>(`@`0xc000.0000.3f80.0000)  !>((get-item:la (conj:la (fill:la m1 0x4000.0000.3f80.0000)) ~[0 0]))  ::  conj(1+2i)=1-2i
+  ==
+::  comparisons return complex 1 (one=0x3f80.0000) / 0 (zero=0x0)
+++  test-cplx-compare  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x3f80.0000)  !>((bin equ:la 0x4000.0000.3f80.0000 0x4000.0000.3f80.0000))  ::  eq -> 1
+    %+  expect-eq  !>(`@`0x0)          !>((bin equ:la 0x4000.0000.3f80.0000 0x4080.0000.4040.0000))  ::  neq -> 0
+    %+  expect-eq  !>(`@`0x3f80.0000)  !>((bin neq:la 0x4000.0000.3f80.0000 0x4080.0000.4040.0000))  ::  neq -> 1
+  ==
+::  ones builder uses the %cplx constant 1+0i = 0x3f80.0000
+++  test-cplx-ones  ^-  tang
+  =/  m=meta  [~[2 2] 6 %cplx ~]
+  %+  expect-eq  !>(`@`0x3f80.0000)  !>((get-item:la (ones:la m) ~[0 0]))
+::  cumsum over [1+2i 3+4i -2-2i] = 2+4i
+++  test-cplx-cumsum  ^-  tang
+  =/  r=ray  (fill:la [~[1 3] 6 %cplx ~] 0x0)
+  =.  r  (set-item:la r ~[0 0] 0x4000.0000.3f80.0000)   ::  1+2i
+  =.  r  (set-item:la r ~[0 1] 0x4080.0000.4040.0000)   ::  3+4i
+  =.  r  (set-item:la r ~[0 2] 0xc000.0000.c000.0000)   ::  -2-2i
+  %+  expect-eq  !>(`@`0x4080.0000.4000.0000)  !>((get-item:la (cumsum:la r) ~[0 0]))   ::  2+4i
+::  bilinear dot vs Hermitian dotc over [1+2i 3+4i].[5+6i 7+8i]
+::  dot  = sum x*y       = -18+68i (0x4288.0000.c190.0000)
+::  dotc = sum conj(x)*y =  70-8i  (0xc100.0000.428c.0000)
+++  test-cplx-dot  ^-  tang
+  =/  m=meta  [~[1 2] 6 %cplx ~]
+  =/  a=ray  (fill:la m 0x0)
+  =.  a  (set-item:la a ~[0 0] 0x4000.0000.3f80.0000)   ::  1+2i
+  =.  a  (set-item:la a ~[0 1] 0x4080.0000.4040.0000)   ::  3+4i
+  =/  b=ray  (fill:la m 0x0)
+  =.  b  (set-item:la b ~[0 0] 0x40c0.0000.40a0.0000)   ::  5+6i
+  =.  b  (set-item:la b ~[0 1] 0x4100.0000.40e0.0000)   ::  7+8i
+  ;:  weld
+    %+  expect-eq  !>(`@`0x4288.0000.c190.0000)  !>((get-item:la (dot:la a b) ~[0 0]))
+    %+  expect-eq  !>(`@`0xc100.0000.428c.0000)  !>((get-item:la (dotc:la a b) ~[0 0]))
+  ==
+::  complex matrix multiply [[1+1i 2+0i][0 1+0i]] x [[1+0i 0][0 1+1i]]
+::  = [[1+1i 2+2i][0 1+1i]]
+++  test-cplx-mmul  ^-  tang
+  =/  m=meta  [~[2 2] 6 %cplx ~]
+  =/  a=ray  (fill:la m 0x0)
+  =.  a  (set-item:la a ~[0 0] 0x3f80.0000.3f80.0000)   ::  1+1i
+  =.  a  (set-item:la a ~[0 1] 0x4000.0000)             ::  2+0i
+  =.  a  (set-item:la a ~[1 0] 0x0)                     ::  0
+  =.  a  (set-item:la a ~[1 1] 0x3f80.0000)             ::  1+0i
+  =/  b=ray  (fill:la m 0x0)
+  =.  b  (set-item:la b ~[0 0] 0x3f80.0000)             ::  1+0i
+  =.  b  (set-item:la b ~[0 1] 0x0)                     ::  0
+  =.  b  (set-item:la b ~[1 0] 0x0)                     ::  0
+  =.  b  (set-item:la b ~[1 1] 0x3f80.0000.3f80.0000)   ::  1+1i
+  =/  c=ray  (mmul:la a b)
+  ;:  weld
+    %+  expect-eq  !>(`@`0x3f80.0000.3f80.0000)  !>((get-item:la c ~[0 0]))   ::  1+1i
+    %+  expect-eq  !>(`@`0x4000.0000.4000.0000)  !>((get-item:la c ~[0 1]))   ::  2+2i
+    %+  expect-eq  !>(`@`0x0)                     !>((get-item:la c ~[1 0]))   ::  0
+    %+  expect-eq  !>(`@`0x3f80.0000.3f80.0000)  !>((get-item:la c ~[1 1]))   ::  1+1i
+  ==
+--

--- a/libmath/desk/lib/complex.hoon
+++ b/libmath/desk/lib/complex.hoon
@@ -1,0 +1,128 @@
+::::  /lib/complex -- complex-number arithmetic over IEEE-754 component floats
+::::  ~2026.6.5
+::
+::  A complex value is a packed atom with the REAL component in the low
+::  2^(bloq-1) bits and the IMAGINARY component in the high bits.  This matches
+::  SoftBLAS `complexN_t { real; imag }` over little-endian bytes, so an array
+::  of these packed elements IS a BLAS interleaved complex array (re0, im0,
+::  re1, im1, ...) and a future jet can cast the data straight to complexN_t*.
+::
+::  Aura family @c (complex), parallel to @r (real); each @c? is a packed pair
+::  of the corresponding @r? component float:
+::
+::    @ch  complex-half    = 2 x @rh (16b)  = 32-bit element
+::    @cs  complex-single  = 2 x @rs (32b)  = 64-bit element   (BLAS  c )
+::    @cd  complex-double  = 2 x @rd (64b)  = 128-bit element  (BLAS  z )
+::    @cq  complex-quad    = 2 x @rq (128b) = 256-bit element
+::
+::  Each width is a door keyed on the rounding mode; arms take and return
+::  PACKED complex atoms.  @cs and @cd ship first (BLAS c/z); @ch/@cq are
+::  additive copies later.  Complex has no total order, so there is
+::  intentionally no gth/gte/lth/lte -- only equ/neq.
+::
+|%
++$  rounding-mode  ?(%n %u %d %z)
+::    +cs: complex-single (@cs), two @rs (32-bit) components.
+++  cs
+  |_  rnd=rounding-mode
+  ::  component accessors / constructor (real low, imag high)
+  ++  re    |=(p=@ `@rs`(end [0 32] p))
+  ++  im    |=(p=@ `@rs`(rsh [0 32] p))
+  ++  pak   |=([r=@rs i=@rs] ^-(@ (con `@`r (lsh [0 32] `@`i))))
+  ::  component helpers
+  ++  fneg  |=(x=@rs (~(sub rs rnd) .0 x))
+  ++  fabs  |=(x=@rs ?:((~(lth rs rnd) x .0) (~(sub rs rnd) .0 x) x))
+  ::  constants
+  ++  zero  ^-(@ 0)
+  ++  one   (pak .1 .0)
+  ::  arithmetic
+  ++  add   |=([p=@ q=@] (pak (~(add rs rnd) (re p) (re q)) (~(add rs rnd) (im p) (im q))))
+  ++  sub   |=([p=@ q=@] (pak (~(sub rs rnd) (re p) (re q)) (~(sub rs rnd) (im p) (im q))))
+  ++  neg   |=(p=@ (pak (fneg (re p)) (fneg (im p))))
+  ++  conj  |=(p=@ (pak (re p) (fneg (im p))))
+  ++  mul
+    |=  [p=@ q=@]
+    =/  ar  (re p)  =/  ai  (im p)
+    =/  br  (re q)  =/  bi  (im q)
+    %+  pak
+      (~(sub rs rnd) (~(mul rs rnd) ar br) (~(mul rs rnd) ai bi))
+    (~(add rs rnd) (~(mul rs rnd) ar bi) (~(mul rs rnd) ai br))
+  ::  +div: Smith's algorithm (scale by the larger denominator component).
+  ++  div
+    |=  [p=@ q=@]
+    =/  ar  (re p)  =/  ai  (im p)
+    =/  br  (re q)  =/  bi  (im q)
+    ?:  (~(gte rs rnd) (fabs br) (fabs bi))
+      =/  r   (~(div rs rnd) bi br)
+      =/  dn  (~(add rs rnd) br (~(mul rs rnd) bi r))
+      %+  pak
+        (~(div rs rnd) (~(add rs rnd) ar (~(mul rs rnd) ai r)) dn)
+      (~(div rs rnd) (~(sub rs rnd) ai (~(mul rs rnd) ar r)) dn)
+    =/  r   (~(div rs rnd) br bi)
+    =/  dn  (~(add rs rnd) (~(mul rs rnd) br r) bi)
+    %+  pak
+      (~(div rs rnd) (~(add rs rnd) (~(mul rs rnd) ar r) ai) dn)
+    (~(div rs rnd) (~(sub rs rnd) (~(mul rs rnd) ai r) ar) dn)
+  ::  +abs: modulus |z| as a real-valued complex [|z|, 0], via hypot.
+  ++  abs
+    |=  p=@
+    =/  xr  (fabs (re p))  =/  xi  (fabs (im p))
+    ?:  &(=(`@rs`.0 xr) =(`@rs`.0 xi))  (pak .0 .0)
+    ?:  (~(gte rs rnd) xr xi)
+      =/  t  (~(div rs rnd) xi xr)
+      (pak (~(mul rs rnd) xr (~(sqt rs rnd) (~(add rs rnd) .1 (~(mul rs rnd) t t)))) .0)
+    =/  t  (~(div rs rnd) xr xi)
+    (pak (~(mul rs rnd) xi (~(sqt rs rnd) (~(add rs rnd) .1 (~(mul rs rnd) t t)))) .0)
+  ::  +equ/+neq: bit equality of both components (matches the %i754 convention).
+  ++  equ   |=([p=@ q=@] &(=((re p) (re q)) =((im p) (im q))))
+  ++  neq   |=([p=@ q=@] =(| (equ p q)))
+  --
+::    +cd: complex-double (@cd), two @rd (64-bit) components.
+++  cd
+  |_  rnd=rounding-mode
+  ++  re    |=(p=@ `@rd`(end [0 64] p))
+  ++  im    |=(p=@ `@rd`(rsh [0 64] p))
+  ++  pak   |=([r=@rd i=@rd] ^-(@ (con `@`r (lsh [0 64] `@`i))))
+  ++  fneg  |=(x=@rd (~(sub rd rnd) .~0 x))
+  ++  fabs  |=(x=@rd ?:((~(lth rd rnd) x .~0) (~(sub rd rnd) .~0 x) x))
+  ++  zero  ^-(@ 0)
+  ++  one   (pak .~1 .~0)
+  ++  add   |=([p=@ q=@] (pak (~(add rd rnd) (re p) (re q)) (~(add rd rnd) (im p) (im q))))
+  ++  sub   |=([p=@ q=@] (pak (~(sub rd rnd) (re p) (re q)) (~(sub rd rnd) (im p) (im q))))
+  ++  neg   |=(p=@ (pak (fneg (re p)) (fneg (im p))))
+  ++  conj  |=(p=@ (pak (re p) (fneg (im p))))
+  ++  mul
+    |=  [p=@ q=@]
+    =/  ar  (re p)  =/  ai  (im p)
+    =/  br  (re q)  =/  bi  (im q)
+    %+  pak
+      (~(sub rd rnd) (~(mul rd rnd) ar br) (~(mul rd rnd) ai bi))
+    (~(add rd rnd) (~(mul rd rnd) ar bi) (~(mul rd rnd) ai br))
+  ++  div
+    |=  [p=@ q=@]
+    =/  ar  (re p)  =/  ai  (im p)
+    =/  br  (re q)  =/  bi  (im q)
+    ?:  (~(gte rd rnd) (fabs br) (fabs bi))
+      =/  r   (~(div rd rnd) bi br)
+      =/  dn  (~(add rd rnd) br (~(mul rd rnd) bi r))
+      %+  pak
+        (~(div rd rnd) (~(add rd rnd) ar (~(mul rd rnd) ai r)) dn)
+      (~(div rd rnd) (~(sub rd rnd) ai (~(mul rd rnd) ar r)) dn)
+    =/  r   (~(div rd rnd) br bi)
+    =/  dn  (~(add rd rnd) (~(mul rd rnd) br r) bi)
+    %+  pak
+      (~(div rd rnd) (~(add rd rnd) (~(mul rd rnd) ar r) ai) dn)
+    (~(div rd rnd) (~(sub rd rnd) (~(mul rd rnd) ai r) ar) dn)
+  ++  abs
+    |=  p=@
+    =/  xr  (fabs (re p))  =/  xi  (fabs (im p))
+    ?:  &(=(`@rd`.~0 xr) =(`@rd`.~0 xi))  (pak .~0 .~0)
+    ?:  (~(gte rd rnd) xr xi)
+      =/  t  (~(div rd rnd) xi xr)
+      (pak (~(mul rd rnd) xr (~(sqt rd rnd) (~(add rd rnd) .~1 (~(mul rd rnd) t t)))) .~0)
+    =/  t  (~(div rd rnd) xr xi)
+    (pak (~(mul rd rnd) xi (~(sqt rd rnd) (~(add rd rnd) .~1 (~(mul rd rnd) t t)))) .~0)
+  ++  equ   |=([p=@ q=@] &(=((re p) (re q)) =((im p) (im q))))
+  ++  neq   |=([p=@ q=@] =(| (equ p q)))
+  --
+--

--- a/libmath/desk/tests/lib/complex.hoon
+++ b/libmath/desk/tests/lib/complex.hoon
@@ -1,0 +1,52 @@
+/+  *test, complex
+::::  /tests/lib/complex -- complex arithmetic over IEEE-754 components
+::
+::  @cs packs two @rs (real low, imag high); expected values from NumPy
+::  complex64.  1+2i=0x4000.0000.3f80.0000, 3+4i=0x4080.0000.4040.0000.
+::  @cd packs two @rd; values from NumPy complex128.
+::
+^|
+|%
+::  --- complex-single (@cs) ---
+++  test-cs-arith  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x40c0.0000.4080.0000)
+      !>((~(add cs:complex %n) 0x4000.0000.3f80.0000 0x4080.0000.4040.0000))   ::  (1+2i)+(3+4i)=4+6i
+    %+  expect-eq  !>(`@`0xc000.0000.c000.0000)
+      !>((~(sub cs:complex %n) 0x4000.0000.3f80.0000 0x4080.0000.4040.0000))   ::  =-2-2i
+    %+  expect-eq  !>(`@`0x4120.0000.c0a0.0000)
+      !>((~(mul cs:complex %n) 0x4000.0000.3f80.0000 0x4080.0000.4040.0000))   ::  =-5+10i
+    %+  expect-eq  !>(`@`0x4000.0000)
+      !>((~(div cs:complex %n) 0x4000.0000.4000.0000 0x3f80.0000.3f80.0000))   ::  (2+2i)/(1+1i)=2
+  ==
+++  test-cs-unary  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0xc000.0000.bf80.0000)  !>((~(neg cs:complex %n) 0x4000.0000.3f80.0000))   ::  -(1+2i)
+    %+  expect-eq  !>(`@`0xc000.0000.3f80.0000)  !>((~(conj cs:complex %n) 0x4000.0000.3f80.0000))  ::  conj=1-2i
+    %+  expect-eq  !>(`@`0x40a0.0000)            !>((~(abs cs:complex %n) 0x4080.0000.4040.0000))   ::  |3+4i|=5
+    %+  expect-eq  !>(`@`0x3f80.0000)            !>(~(one cs:complex %n))                            ::  1+0i
+  ==
+++  test-cs-compare  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(%.y)  !>((~(equ cs:complex %n) 0x4000.0000.3f80.0000 0x4000.0000.3f80.0000))
+    %+  expect-eq  !>(%.n)  !>((~(equ cs:complex %n) 0x4000.0000.3f80.0000 0x4080.0000.4040.0000))
+    %+  expect-eq  !>(%.y)  !>((~(neq cs:complex %n) 0x4000.0000.3f80.0000 0x4080.0000.4040.0000))
+  ==
+::  --- complex-double (@cd) ---
+++  test-cd-arith  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@`0x4018.0000.0000.0000.4010.0000.0000.0000)
+      !>  %-  ~(add cd:complex %n)
+          :-  0x4000.0000.0000.0000.3ff0.0000.0000.0000
+          0x4010.0000.0000.0000.4008.0000.0000.0000                            ::  (1+2i)+(3+4i)=4+6i
+    %+  expect-eq  !>(`@`0x4024.0000.0000.0000.c014.0000.0000.0000)
+      !>  %-  ~(mul cd:complex %n)
+          :-  0x4000.0000.0000.0000.3ff0.0000.0000.0000
+          0x4010.0000.0000.0000.4008.0000.0000.0000                            ::  =-5+10i
+    %+  expect-eq  !>(`@`0x4000.0000.0000.0000)
+      !>  %-  ~(div cd:complex %n)
+          :-  0x4000.0000.0000.0000.4000.0000.0000.0000
+          0x3ff0.0000.0000.0000.3ff0.0000.0000.0000                            ::  (2+2i)/(1+1i)=2
+    %+  expect-eq  !>(`@`0x3ff0.0000.0000.0000)  !>(~(one cd:complex %n))      ::  1+0i
+  ==
+--

--- a/libmath/tools/complex_check.py
+++ b/libmath/tools/complex_check.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Oracle for /lib/complex and Lagoon %cplx, against NumPy complex64/complex128.
+
+A complex value is packed as a single atom with the REAL component in the low
+2^(bloq-1) bits and the IMAGINARY component in the high bits -- matching
+SoftBLAS complexN_t{real;imag} over little-endian bytes.  @cs (bloq 6) = two
+float32; @cd (bloq 7) = two float64.
+
+Prints the packed hex the Hoon tests assert.  Run:  python3 complex_check.py
+"""
+import numpy as np, struct
+
+
+def pack(z, n):
+    """complex -> packed @c hex; n = component width in bits (32 or 64)."""
+    z = (np.complex64 if n == 32 else np.complex128)(z)
+    if n == 32:
+        re = struct.unpack('<I', struct.pack('<f', float(z.real)))[0]
+        im = struct.unpack('<I', struct.pack('<f', float(z.imag)))[0]
+    else:
+        re = struct.unpack('<Q', struct.pack('<d', float(z.real)))[0]
+        im = struct.unpack('<Q', struct.pack('<d', float(z.imag)))[0]
+    return (im << n) | re
+
+
+def grp(v):
+    """atom -> dotted hex (4-hex-digit groups), Hoon style."""
+    s = '%x' % v
+    out = ''
+    while len(s) > 4:
+        out = '.' + s[-4:] + out
+        s = s[:-4]
+    return '0x' + s + out
+
+
+def show(label, z, n=32):
+    print('  %-26s %s' % (label, grp(pack(z, n))))
+
+
+def main():
+    print('@cs (complex-single, float32 components):')
+    a, b = np.complex64(1 + 2j), np.complex64(3 + 4j)
+    show('1+2i', 1 + 2j)
+    show('3+4i', 3 + 4j)
+    show('add (1+2i)+(3+4i)=4+6i', a + b)
+    show('sub =-2-2i', a - b)
+    show('mul =-5+10i', a * b)
+    show('div (2+2i)/(1+1i)=2', np.complex64(2 + 2j) / np.complex64(1 + 1j))
+    show('conj(1+2i)=1-2i', np.conj(a))
+    show('abs(3+4i)=5', np.complex64(abs(b)))
+    show('one 1+0i', 1 + 0j)
+    show('cumsum [1+2i,3+4i,-2-2i]=2+4i', a + b + np.complex64(-2 - 2j))
+    x = np.array([1 + 2j, 3 + 4j], dtype=np.complex64)
+    y = np.array([5 + 6j, 7 + 8j], dtype=np.complex64)
+    show('dot (bilinear) sum x*y', np.complex64(np.sum(x * y)))
+    show('dotc (hermitian) vdot(x,y)', np.complex64(np.vdot(x, y)))
+    print('  (mmul: [[1+1i,2][0,1]]x[[1,0][0,1+1i]] = [[1+1i,2+2i][0,1+1i]])')
+
+    print('@cd (complex-double, float64 components):')
+    show('1+2i', 1 + 2j, 64)
+    show('3+4i', 3 + 4j, 64)
+    show('add 4+6i', 4 + 6j, 64)
+    show('mul -5+10i', np.complex128(1 + 2j) * np.complex128(3 + 4j), 64)
+    show('div=2', np.complex128(2 + 2j) / np.complex128(1 + 1j), 64)
+    show('one 1+0i', 1 + 0j, 64)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Implements Phase 1 of the `%cplx` design (`lagoon/CPLX-DESIGN.md`, PR #45):
complex-number arrays with a **SoftBLAS-interleaved atom layout**, element-wise
ops, and complex linear algebra. Unblocks Saloon eigenvalues/eigenvectors.

## `/lib/complex` (pure Hoon)
`cs` (`@cs` = two `@rs`) and `cd` (`@cd` = two `@rd`) doors keyed on rounding
mode. Packed atom = **real low / imag high**, matching SoftBLAS `complexN_t`
(validated on ~hex: `(1+2i)·(3+4i) = -5+10i`). Arms: `add`/`sub`/`mul`,
`div` (Smith's algorithm), `neg`, `conj`, `abs` (hypot, returns real-valued
complex), `equ`/`neq` (bit equality). No total order — no `gth`/`lth`.

## Lagoon (`sur` + `lib`)
- `%cplx` in the `kind` union; `bloq` 6=`cs` 7=`cd` (`meta.tail` unused).
- `fun-scalar`: `add`/`sub`/`mul`/`div`, `equ`/`neq` → complex `one`/`zero`;
  `gth`/`gte`/`lth`/`lte` **crash** (complex is unordered).
- New **`%conj`** op (identity on real kinds, so `dotc` ≡ `dot` there);
  `trans-scalar` `%abs`/`%conj`.
- New ray arms **`conj`** and **`dotc`** (Hermitian inner product
  `Σ conj(aᵢ)·bᵢ`). Bilinear `dot`, `mmul`, `cumsum` use the generic
  round-each-step path (no exact complex accumulator).
- `get-term` → `@c` aura terms (`%cs`/`%cd`); `eye`/`ones` constant `1+0i`;
  `scale` raw-pack; `change` out of complex refuses (lossy).

## Tests — all green on ~hex
- `/tests/lib/complex` (4): `cs`/`cd` arith, unary, compare.
- `/tests/lib/lagoon-cplx` (7): arith, unary (abs/conj), compare, ones,
  cumsum, **dot (-18+68i) vs dotc (70-8i)**, complex mmul.
- Regressions: `%unum` (14) and `%int2` (5) still pass.
- Oracle: `tools/complex_check.py` (NumPy `complex64`/`complex128`).

## Not in scope (per design)
Jets (Phase 2: add `*dotu`/`cgemm`/`zgemm` to our SoftBLAS); Saloon `eig`
(Phase 3); `@ch`/`@cq` widths; `change` into-complex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)