### PR TITLE
lagoon: fix %fixp conj/dotc crash

### DIFF
--- a/lagoon/desk/lib/lagoon.hoon
+++ b/lagoon/desk/lib/lagoon.hoon
@@ -1649,10 +1649,12 @@
           %conj  ~(conj ch:complex rnd)
         ==
       ==
-      ::  fixed-point abs is two's-complement abs at the element width.
+      ::  fixed-point abs is two's-complement abs at the element width; conj is
+      ::  the identity (fixed-point is real), so +dotc reduces to +dot.
         %fixp
       ?+  fun  !!
-        %abs  ~(abs twoc:twoc bloq)
+        %abs   ~(abs twoc:twoc bloq)
+        %conj  |=(b=@ b)
       ==
     ==
   ::

--- a/lagoon/desk/tests/lib/lagoon-fixp.hoon
+++ b/lagoon/desk/tests/lib/lagoon-fixp.hoon
@@ -89,4 +89,16 @@
     %+  expect-eq  !>(`@`0x0)  !>((get-item:la c ~[1 0]))   ::  0.0
     %+  expect-eq  !>(`@`0x10)  !>((get-item:la c ~[1 1]))   ::  1.0
   ==
+::  conj is identity on %fixp (real); dotc therefore coincides with dot.
+::  q3.4: 1.5=0x18 2.0=0x20 1.0=0x10 0.5=0x8; [1.5 2.0].[1.0 0.5]=2.5=0x28.
+++  test-fixp-conj-dotc  ^-  tang
+  =/  m2=meta  [~[1 2] 3 %fixp [3 4]]
+  =/  a=ray  (set-item:la (set-item:la (fill:la m2 0x0) ~[0 0] 0x18) ~[0 1] 0x20)
+  =/  b=ray  (set-item:la (set-item:la (fill:la m2 0x0) ~[0 0] 0x10) ~[0 1] 0x8)
+  ;:  weld
+    %+  expect-eq  !>(`@`0x18)
+      !>((get-item:la (conj:la (fill:la [~[1 1] 3 %fixp [3 4]] 0x18)) ~[0 0]))   ::  conj(1.5)=1.5
+    %+  expect-eq  !>(`@`0x28)  !>((get-item:la (dotc:la a b) ~[0 0]))   ::  Sum conj(x)*y=2.5
+    %+  expect-eq  !>(`@`0x28)  !>((get-item:la (dot:la a b) ~[0 0]))    ::  =dot (real)
+  ==
 --


### PR DESCRIPTION
## P0 fix (Gnome/Angel review)

`trans-scalar`'s `%fixp` branch handled only `%abs`; `%conj` fell through to `!!`. So **`+conj` crashed on any `%fixp` array**, and since `+dotc = (dot (conj a) b)`, **`+dotc` crashed too** — while the `conj`/`dotc` doccords explicitly claim "identity on real kinds" (`%fixp` is real). Both lagoon review agents flagged this independently.

**Fix:** one line — `%conj |=(b=@ b)` in the `%fixp` branch, matching every other real kind (`%uint`/`%int2`/`%i754`/`%unum`).

**Test:** `test-fixp-conj-dotc` — `conj(1.5)=1.5`, and `dotc = dot = 2.5` over q3.4 `[1.5 2.0]·[1.0 0.5]` (verifying dotc reduces to dot on a real kind). All 8 lagoon-fixp tests pass on a live ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)