### PR TITLE
lagoon: %i754 %mod -> C fmod + NaN guard (Hoon; jet follow-on)

### DIFF
--- a/lagoon/desk/lib/lagoon.hoon
+++ b/lagoon/desk/lib/lagoon.hoon
@@ -1344,6 +1344,14 @@
       ==
       ::
         %i754
+      ::  %mod is C fmod: a - b*trunc(a/b), truncating the quotient TOWARD ZERO
+      ::  (so the result takes the sign of the dividend), matching %unum.  A zero
+      ::  divisor or a non-finite operand makes the quotient non-representable as
+      ::  an integer (toi -> ~) and returns NaN rather than crashing.
+      ::  NOTE (Vere follow-on): the f32/f64 %mod jet in vere's lagoon.c still
+      ::  does round-nearest (IEEE remainder) and returns the dividend on /0, so
+      ::  on a jetted ship f32/f64 disagree with this Hoon (and with the
+      ::  un-jetted @rq path).  The jet must be updated to C fmod + NaN-on-/0.
       ?+    `^bloq`bloq  !!
           %7
         ?+  fun  !!
@@ -1351,7 +1359,7 @@
           %sub  ~(sub rq rnd)
           %mul  ~(mul rq rnd)
           %div  ~(div rq rnd)
-          %mod  |=([a=@rq b=@rq] (~(sub rq rnd) a (~(mul rq rnd) b (~(san rq rnd) (need (~(toi rq rnd) (~(div rq rnd) a b)))))))
+          %mod  |=([a=@rq b=@rq] ^-(@rq ?:((~(equ rq rnd) b .~~~0) `@rq`0x7fff.8000.0000.0000.0000.0000.0000.0000 =/(u (~(toi rq %z) (~(div rq rnd) a b)) ?~(u `@rq`0x7fff.8000.0000.0000.0000.0000.0000.0000 (~(sub rq rnd) a (~(mul rq rnd) b (~(san rq rnd) u.u))))))))
           %gth  |=([a=@rq b=@rq] ?:((~(gth rq rnd) a b) .~~~1 .~~~0))
           %gte  |=([a=@rq b=@rq] ?:((~(gte rq rnd) a b) .~~~1 .~~~0))
           %lth  |=([a=@rq b=@rq] ?:((~(lth rq rnd) a b) .~~~1 .~~~0))
@@ -1365,7 +1373,7 @@
           %sub  ~(sub rd rnd)
           %mul  ~(mul rd rnd)
           %div  ~(div rd rnd)
-          %mod  |=([a=@rd b=@rd] (~(sub rd rnd) a (~(mul rd rnd) b (~(san rd rnd) (need (~(toi rd rnd) (~(div rd rnd) a b)))))))
+          %mod  |=([a=@rd b=@rd] ^-(@rd ?:((~(equ rd rnd) b .~0) `@rd`0x7ff8.0000.0000.0000 =/(u (~(toi rd %z) (~(div rd rnd) a b)) ?~(u `@rd`0x7ff8.0000.0000.0000 (~(sub rd rnd) a (~(mul rd rnd) b (~(san rd rnd) u.u))))))))
           %gth  |=([a=@rd b=@rd] ?:((~(gth rd rnd) a b) .~1 .~0))
           %gte  |=([a=@rd b=@rd] ?:((~(gte rd rnd) a b) .~1 .~0))
           %lth  |=([a=@rd b=@rd] ?:((~(lth rd rnd) a b) .~1 .~0))
@@ -1379,7 +1387,7 @@
           %sub  ~(sub rs rnd)
           %mul  ~(mul rs rnd)
           %div  ~(div rs rnd)
-          %mod  |=([a=@rs b=@rs] (~(sub rs rnd) a (~(mul rs rnd) b (~(san rs rnd) (need (~(toi rs rnd) (~(div rs rnd) a b)))))))
+          %mod  |=([a=@rs b=@rs] ^-(@rs ?:((~(equ rs rnd) b .0) `@rs`0x7fc0.0000 =/(u (~(toi rs %z) (~(div rs rnd) a b)) ?~(u `@rs`0x7fc0.0000 (~(sub rs rnd) a (~(mul rs rnd) b (~(san rs rnd) u.u))))))))
           %gth  |=([a=@rs b=@rs] ?:((~(gth rs rnd) a b) .1 .0))
           %gte  |=([a=@rs b=@rs] ?:((~(gte rs rnd) a b) .1 .0))
           %lth  |=([a=@rs b=@rs] ?:((~(lth rs rnd) a b) .1 .0))
@@ -1393,7 +1401,7 @@
           %sub  ~(sub rh rnd)
           %mul  ~(mul rh rnd)
           %div  ~(div rh rnd)
-          %mod  |=([a=@rh b=@rh] (~(sub rh rnd) a (~(mul rh rnd) b (~(san rh rnd) (need (~(toi rh rnd) (~(div rh rnd) a b)))))))
+          %mod  |=([a=@rh b=@rh] ^-(@rh ?:((~(equ rh rnd) b .~~0) `@rh`0x7e00 =/(u (~(toi rh %z) (~(div rh rnd) a b)) ?~(u `@rh`0x7e00 (~(sub rh rnd) a (~(mul rh rnd) b (~(san rh rnd) u.u))))))))
           %gth  |=([a=@rh b=@rh] ?:((~(gth rh rnd) a b) .~~1 .~~0))
           %gte  |=([a=@rh b=@rh] ?:((~(gte rh rnd) a b) .~~1 .~~0))
           %lth  |=([a=@rh b=@rh] ?:((~(lth rh rnd) a b) .~~1 .~~0))

--- a/lagoon/desk/tests/lib/lagoon-arithmetic.hoon
+++ b/lagoon/desk/tests/lib/lagoon-arithmetic.hoon
@@ -108,8 +108,11 @@
   |=  m=meta
   (is-equal (fill:la m 0) (mod:la (fill:la m 1) (fill:la m 1)))
 ::
-::  Regression: mod must round the quotient with the active mode (default
-::  %n, round-nearest), not truncate.  5 mod 3 = 5 - 3*round(5/3) = -1.
+::  %mod ray op is JETTED per width and the jet is inconsistent: this asserts
+::  the CURRENT f64 jet (round-nearest / IEEE remainder), 5 mod 3 = -1.  The Hoon
+::  spec (+fun-scalar) and the quad jet (test-mods-7r) are C fmod = 2.
+::  Reconciling the f32/f64 jet to C fmod + NaN-on-/0 is a Vere follow-on
+::  (lagoon.c); this test documents today's behavior, not the spec.
 ++  test-mod-nearest-6r  ^-  tang
   =/  m  `meta`[~[1 1] 6 %i754 ~]
   (is-equal (fill:la m .~-1) (mod:(lake %n) (fill:la m .~5) (fill:la m .~3)))


### PR DESCRIPTION
## P0 fix (Gnome/Angel review) — Hoon spec; **Vere jet follow-on required**

The Hoon `%i754 %mod` was `a - b*san(need(toi(a/b)))`:
- `toi` rounds to **nearest** → IEEE remainder, not C fmod.
- `need` **crashes** on a non-finite quotient (`b=0` → `Inf` → `toi ~` → bail).

**Fix:** C fmod, matching `%unum` — truncate the quotient toward zero (force `%z` in `toi`, result takes the dividend's sign), and guard a zero divisor (explicit `equ`-0) and non-finite operands (`toi → ~`) → **NaN, not a crash**. All four widths.

## ⚠️ This is the Hoon spec; the jet is shadowing it

Investigating on a jetted ship revealed the ray `mod` op is **jetted per width in vere's `lagoon.c`, inconsistently**:

| width | jet `5 mod 3` | jet `5 mod 0` |
|-------|---------------|---------------|
| f64 | `−1` (round-nearest / IEEE remainder) | `5.0` (dividend, no guard) |
| f128 | `2` (C fmod) | `5.0` (dividend, no guard) |

So on a jetted ship this Hoon is **shadowed** and f32/f64 still disagree with the spec. **Reconciling the f32/f64 jet to C fmod + NaN-on-÷0 is a required Vere follow-on** (`vere/.../jets/i/lagoon.c`, coordinate with the `neal/lagoon-jet-fixes` SoftBLAS-migration branch). Until then jet ≠ Hoon for f32/f64 — a parity gap to close in vere.

Per option 3 (agreed): land the Hoon spec without spec-asserting ray-mod tests. The existing tests now **document current jet behavior**, not the spec (`test-mod-nearest-6r` = f64 jet round-nearest; `test-mods-7r` = quad jet C fmod), with comments saying so. The Hoon builds clean; full lagoon-arithmetic suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)