### PR TITLE
docs+: P3 transparency cleanup (round-bankers, rd.log(-inf), stale docs)

### DIFF
--- a/lagoon/README.md
+++ b/lagoon/README.md
@@ -23,15 +23,18 @@ We envision four libraries and associated jet code living in this repository:
 
 ##  Type System
 
-- `%real` IEEE 754 float (currently supported)
-- `%cplx` IEEE 754 float/BLAS packed complex (planned)
-- `%uint` unsigned integers (currently supported)
-- `%int2` signed twos-complement integers (planned)
-- `%sint` signed ZigZag integers (planned)
-- `%unum` → subdivide into one of:
-  - `%post` posits (32-bit or 16-bit) (planned)
-  - `%vald` valids (32-bit or 16-bit) (planned)
-- `%fixp` fixed-precision (planned)
+The element `kind` lives in `/sur/lagoon` (the old `%real` is now `%i754`):
+
+- `%i754` IEEE 754 float — `@rh`/`@rs`/`@rd`/`@rq` (supported)
+- `%uint` unsigned integers (supported)
+- `%int2` signed two's-complement integers, `/lib/twoc` (supported)
+- `%unum` unum/posits — `@rpb`/`@rph`/`@rps`/`@rpd`, `/lib/unum` (supported)
+- `%cplx` BLAS-packed complex — `@ch`/`@cs`/`@cd`/`@cq`, `/lib/complex` (supported)
+- `%fixp` fixed-point Q a.b, `/lib/fixed`; precision `[a b]` in `meta.tail` (supported)
+
+(`%sint` ZigZag integers and `%vald` valids remain possible future additions.)
+Arms added since the `%real`-only release below include `++dotc` (Hermitian dot)
+and `++conj` (elementwise conjugate); Saloon adds eigendecomposition (`++eig`).
 
 ##  Fixed-Point Library `/lib/fixed`
 

--- a/lagoon/desk/lib/lagoon.hoon
+++ b/lagoon/desk/lib/lagoon.hoon
@@ -355,6 +355,10 @@
       (^rip a b)
     --
   ::
+  ::  +check: validate a ray's data length against its shape.  The data atom
+  ::  carries a 0x1 most-significant "pin" above the elements (so leading-zero
+  ::  elements aren't lost), hence (met bloq data) counts prod(shape)+1 blocks;
+  ::  this asserts prod(shape) == (met ...) - 1.  Every public arm calls it.
   ++  check
     |=  =ray
     ^-  ?
@@ -426,8 +430,9 @@
       ::
         %i754
       ?+    kind  !!
-          :: %i754 -> %uint
-          :: XXX will incorrectly convert negative values to %uint
+          :: %i754 -> %uint.  KNOWN LIMITATION: a negative %i754 value has no
+          :: %uint representation; +toi yields a negative @s and the (div ... 2)
+          :: wraps it rather than clamping/erroring.  Callers must pre-clamp.
           %uint
         %-  en-ray
         :-  [shape.meta.ray bloq %uint tail.meta.ray]

--- a/lagoon/desk/sur/lagoon.hoon
+++ b/lagoon/desk/sur/lagoon.hoon
@@ -12,7 +12,10 @@
   $:  shape=(list @)  ::  list of dimension lengths
       =bloq           ::  logarithm of bitwidth
       =kind           ::  name of data type
-      tail=*          ::  placeholder for future data (jet convenience)
+      tail=*          ::  per-kind specialization data (~ unless a kind needs
+                      ::  it).  Deliberately last and untyped so a kind can add
+                      ::  data without rewriting the jet axes.  %fixp uses it for
+                      ::  the [a=@ b=@] fixed-point precision; other kinds: ~.
   ==
 ::
 +$  kind              ::  $kind:  type of array scalars
@@ -20,7 +23,7 @@
       %uint           ::  unsigned integer
       %int2           ::  2s-complement integer (/lib/twoc)
       %unum           ::  unum/posit (/lib/unum) @rpb @rph @rps @rpd
-      %cplx           ::  complex (/lib/complex) @cs/@cd; bloq = total width
+      %cplx           ::  complex (/lib/complex) @ch/@cs/@cd/@cq; bloq=total width
       %fixp           ::  fixed-point Q a.b (/lib/fixed); prec [a b] in meta.tail
   ==
 ::

--- a/libmath/desk/lib/math.hoon
+++ b/libmath/desk/lib/math.hoon
@@ -92,10 +92,11 @@
   ++  huge  `@rs`0x7f80.0000  ::  3.40282346638528859812e+38
   ::    +tiny:  @rs
   ::
-  ::  Returns the value of the smallest representable normal number.
+  ::  Returns the smallest representable positive (subnormal) number, 2^-149.
+  ::  (Not the smallest NORMAL, which is 2^-126 = .1.1754944e-38.)
   ::    Examples
   ::      > tiny
-  ::      .1.1754944e-38
+  ::      .1e-45
   ::  Source
   ++  tiny  `@rs`0x1          ::  1.40129846432481707092e-45
   ::
@@ -874,22 +875,20 @@
   ::    +round-bankers:  @rs -> @rs
   ::
   ::  Returns the floating-point atom rounded to the nearest integer, with
-  ::  ties rounded to the nearest even integer.
+  ::  ties rounded to the nearest even integer (banker's rounding).  This is
+  ::  exactly what +toi does under round-nearest (%n), which ties to even, so we
+  ::  force %n regardless of the door's configured mode.
   ::    Examples
-  ::      > (round-bankers .1)
-  ::      .1
   ::      > (round-bankers .1.5)
+  ::      .2
+  ::      > (round-bankers .2.5)
   ::      .2
   ::      > (round-bankers .1.49)
   ::      .1
   ::  Source
   ++  round-bankers
     |=  x=@rs  ^-  @rs
-    =/  int  (san (need (toi x)))
-    =/  dcm  (sub x int)
-    ?:  (lth dcm .0.5)
-      int
-    (add int .1)
+    (san (need (~(toi ^rs %n) x)))
   --
 ::  double precision
 ++  rd
@@ -1556,10 +1555,10 @@
     |=  z=@rd  ^-  @rd
     ::  filter out non-finite arguments
     ::    check infinities
-    ?:  =(z 0x7ff0.0000.0000.0000)  `@rd`0x7ff0.0000.0000.0000  :: exp(+inf) -> inf
-    ?:  =(z 0xfff0.0000.0000.0000)  .~0.0                       :: exp(-inf) -> 0
+    ?:  =(z 0x7ff0.0000.0000.0000)  `@rd`0x7ff0.0000.0000.0000  :: log(+inf) -> inf
+    ?:  =(z 0xfff0.0000.0000.0000)  `@rd`0x7ff8.0000.0000.0000  :: log(-inf) -> NaN
     ::    check NaN
-    ?.  (^gte (dis 0x7ff8.0000.0000.0000 z) 0)  `@rd`0x7ff8.0000.0000.0000  :: exp(NaN) -> NaN
+    ?.  (^gte (dis 0x7ff8.0000.0000.0000 z) 0)  `@rd`0x7ff8.0000.0000.0000  :: log(NaN) -> NaN
     ::  otherwise, use Taylor series
     =/  p   .~0
     =/  po  .~-1
@@ -1742,23 +1741,21 @@
     (div rnd-mantissa scaling)
   ::    +round-bankers:  @rs -> @rs
   ::
-  ::  Returns the floating-point atom rounded to the nearest integer, with
-  ::  ties rounded to the nearest even integer.
+  ::  Returns the floating-point atom rounded to the nearest integer, with ties
+  ::  rounded to the nearest even integer (banker's rounding).  This is exactly
+  ::  what +toi does under round-nearest (%n), which ties to even, so we force
+  ::  %n regardless of the door's configured mode.
   ::    Examples
-  ::      > (round-bankers .1)
-  ::      .1
-  ::      > (round-bankers .1.5)
-  ::      .2
-  ::      > (round-bankers .1.49)
-  ::      .1
+  ::      > (round-bankers .~1.5)
+  ::      .~2
+  ::      > (round-bankers .~2.5)
+  ::      .~2
+  ::      > (round-bankers .~1.49)
+  ::      .~1
   ::  Source
   ++  round-bankers
     |=  x=@rd  ^-  @rd
-    =/  int  (san (need (toi x)))
-    =/  dcm  (sub x int)
-    ?:  (lth dcm .~0.5)
-      int
-    (add int .~1)
+    (san (need (~(toi ^rd %n) x)))
   --
 ::  half precision
 ++  rh
@@ -1849,10 +1846,11 @@
   ++  huge  `@rh`0x7bff  ::  6.55e+04
   ::    +tiny:  @rh
   ::
-  ::  Returns the value of the smallest representable normal number.
+  ::  Returns the smallest representable positive (subnormal) number, 2^-24.
+  ::  (Not the smallest NORMAL, which is 2^-14 = .~~6.10e-05.)
   ::    Examples
   ::      > tiny
-  ::      .~~6.10e-05
+  ::      .~~6e-8
   ::  Source
   ++  tiny  `@rh`0x1     ::  6e-08
   ::

--- a/libmath/desk/tests/lib/math-rounding.hoon
+++ b/libmath/desk/tests/lib/math-rounding.hoon
@@ -1,0 +1,23 @@
+/+  *test, math
+::::  /tests/lib/math-rounding -- round-bankers (ties-to-even) + log(-inf)
+::
+^|
+|%
+::  round-bankers ties to the nearest EVEN integer (banker's rounding).
+++  test-round-bankers  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@rs`.2)  !>((~(round-bankers rs:math [%n .1e-5]) .2.5))   ::  -> 2 (even)
+    %+  expect-eq  !>(`@rs`.2)  !>((~(round-bankers rs:math [%n .1e-5]) .1.5))   ::  -> 2 (even)
+    %+  expect-eq  !>(`@rs`.4)  !>((~(round-bankers rs:math [%n .1e-5]) .3.5))   ::  -> 4 (even)
+    %+  expect-eq  !>(`@rs`.1)  !>((~(round-bankers rs:math [%n .1e-5]) .1.49))  ::  -> 1
+    %+  expect-eq  !>(`@rd`.~2)  !>((~(round-bankers rd:math [%n .~1e-10]) .~2.5))
+  ==
+::  log(-inf) is NaN (was 0.0 in the rd door -- a copy-paste from exp).
+++  test-log-ninf  ^-  tang
+  ;:  weld
+    %+  expect-eq  !>(`@rd`0x7ff8.0000.0000.0000)
+      !>((~(log rd:math [%n .~1e-10]) `@rd`0xfff0.0000.0000.0000))
+    %+  expect-eq  !>(`@rs`0x7fc0.0000)
+      !>((~(log rs:math [%n .1e-5]) `@rs`0xff80.0000))
+  ==
+--

--- a/saloon/README.md
+++ b/saloon/README.md
@@ -36,6 +36,17 @@ Logical functions:
 - `all-close` (pass-through from Lagoon `++all`)
 - `any-close` (pass-through from Lagoon `++any`)
 
+Linear algebra (over Lagoon arrays):
+
+- `++eig`, eigendecomposition of a **symmetric** (`%i754`) or **Hermitian**
+  (`%cplx`) matrix via cyclic Jacobi → `[vals=ray vecs=ray]` (real eigenvalues,
+  orthonormal/unitary eigenvectors as columns).  Dispatches on `kind`.
+- `++eigvals`, eigenvalues only (1-D ray).
+- `++eigvecs`, eigenvectors only.
+
+Set rounding mode and tolerance with `++sake` before calling `++eig` (the bare
+`++sa` default `rtol` is unusable); `rtol`'s width must match the component.
+
 ##  References
 
 - Milton Abramowitz & Irene Stegun, _Handbook of Mathematical Functions with Formulas, Graphs, and Mathematical Tables_.  1964–2010.

--- a/saloon/desk/lib/saloon.hoon
+++ b/saloon/desk/lib/saloon.hoon
@@ -80,7 +80,7 @@
   ::  Returns the BOOLEAN comparison of two floating-point rays, greater than
   ::    Examples
   ::      > (gth:sa:sa (ones:la:la [~[5 1] 5 %i754 ~]) (en-ray:la:la [~[5 1] 5 %i754 ~] ~[.1 .0 .1 .2 .0]))
-  ::      [meta=[shape=~[5 1] bloq=5 kind=%i754 fxp=~] data=data=0x1.0000.0000.3f80.0000.0000.0000.0000.0000.3f80.0000]
+  ::      [meta=[shape=~[5 1] bloq=5 kind=%i754 fxp=~] data=0x1.0000.0000.3f80.0000.0000.0000.0000.0000.3f80.0000]
   ::      > ;;((list (list @rs)) data:(de-ray:la:la (gth:sa:sa (ones:la:la [~[5 1] 5 %i754 ~]) (en-ray:la:la [~[5 1] 5 %i754 ~] ~[.1 .0 .1 .2 .0]))))
   ::      [i=~[.0] t=[i=~[.1] t=~[~[.0] ~[.0] ~[.1]]]]
   ::  Source
@@ -90,7 +90,7 @@
   ::  Returns the BOOLEAN comparison of two floating-point rays, greater than or equal to
   ::    Examples
   ::      > (gte:sa:sa (ones:la:la [~[5 1] 5 %i754 ~]) (en-ray:la:la [~[5 1] 5 %i754 ~] ~[.1 .0 .1 .2 .0]))
-  ::      [meta=[shape=~[5 1] bloq=5 kind=%i754 fxp=~] data=data=0x1.3f80.0000.3f80.0000.3f80.0000.0000.0000.3f80.0000]
+  ::      [meta=[shape=~[5 1] bloq=5 kind=%i754 fxp=~] data=0x1.3f80.0000.3f80.0000.3f80.0000.0000.0000.3f80.0000]
   ::      > ;;((list (list @rs)) data:(de-ray:la:la (gte:sa:sa (ones:la:la [~[5 1] 5 %i754 ~]) (en-ray:la:la [~[5 1] 5 %i754 ~] ~[.1 .0 .1 .2 .0]))))
   ::      [i=~[.1] t=[i=~[.1] t=~[~[.1] ~[.0] ~[.1]]]]
   ::  Source
@@ -101,14 +101,14 @@
   ::  Alias for +gte.
   ::    Examples
   ::      > (geq:sa:sa (ones:la:la [~[5 1] 5 %i754 ~]) (en-ray:la:la [~[5 1] 5 %i754 ~] ~[.1 .0 .1 .2 .0]))
-  ::      [meta=[shape=~[5 1] bloq=5 kind=%i754 fxp=~] data=data=0x1.3f80.0000.3f80.0000.3f80.0000.0000.0000.3f80.0000]
+  ::      [meta=[shape=~[5 1] bloq=5 kind=%i754 fxp=~] data=0x1.3f80.0000.3f80.0000.3f80.0000.0000.0000.3f80.0000]
   ::      > ;;((list (list @rs)) data:(de-ray:la:la (geq:sa:sa (ones:la:la [~[5 1] 5 %i754 ~]) (en-ray:la:la [~[5 1] 5 %i754 ~] ~[.1 .0 .1 .2 .0]))))
   ::      [i=~[.1] t=[i=~[.1] t=~[~[.1] ~[.0] ~[.1]]]]
   ::  Source
   ++  geq  gte:(lake rnd)
   ::    +neq:  [$ray $ray] -> $ray
   ::
-  ::  Returns the BOOLEAN comparison of two floating-point rays, equal to
+  ::  Returns the BOOLEAN comparison of two floating-point rays, not equal to
   ::    Examples
   ::      > (neq:la:la (ones:la:la [~[5 1] 5 %i754 ~]) (en-ray:la:la [~[5 1] 5 %i754 ~] ~[.1 .0 .1 .2 .0]))
   ::      [meta=[shape=~[5 1] bloq=5 kind=%i754 fxp=~] data=0x1.0000.0000.3f80.0000.0000.0000.3f80.0000.3f80.0000]


### PR DESCRIPTION
## P3 — docs/traceability batch (Gnome/Angel review)

Mostly comments/docstrings/READMEs, plus two trivial correctness one-liners with tests.

### Behavioral (with tests) — `math.hoon`
- **`round-bankers` now actually rounds half-to-even.** It was half-up: it took the already-`toi`-rounded value and bumped ties up, so `round-bankers(2.5)` → 3 (not 2). `toi` under `%n` ties to even, so force `^rs`/`^rd %n`. → `test-round-bankers` (2.5→2, 1.5→2, 3.5→4).
- **`rd.log(-inf)` returns NaN** (was `0.0` — a copy-paste from `exp`; `rs.log` was already correct). Also fixed the stray `exp(...)` comments in the `rd.log` branch. → `test-log-ninf`.

### Docs / comments
- **`math.hoon` `tiny`** (rs/rh): docstring/example said "smallest normal" but the value is the smallest **subnormal** (`2^-149` / `2^-24`) — corrected, with a pointer to the normal.
- **`sur/lagoon.hoon`**: `%cplx` listed `@cs/@cd` → now `@ch/@cs/@cd/@cq`; augmented the `tail=*` comment to explain it's *deliberate* per-kind specialization space (slots in without rewriting jet axes — per the design rationale; `%fixp` uses it for precision).
- **`lagoon.hoon`**: documented `+check` (the `0x1`-pin / `prod(shape)` invariant every public arm relies on) and the known `%i754→%uint` negative-value limitation (was a bare `XXX`).
- **`saloon.hoon`**: `+neq` doccord said "equal to" → "not equal to"; fixed the `data=data=` typos in the `gth`/`gte`/`geq` examples.
- **READMEs**: lagoon Type System refreshed (`%real`→`%i754`; all six kinds shipped, not "planned"); saloon gains a linear-algebra (`eig`/`eigvals`/`eigvecs`) section.

All edits are in regions disjoint from the open PRs (#50–#53), so no conflicts expected. `math.hoon`, `lagoon.hoon`, `saloon.hoon` all rebuild green; the new `math-rounding` tests pass.

(Deferred to the #18 Chebyshev rewrite, already noted there: the `log` hang, `exp` cancellation, `asin`/`acos` & `sqt(-0)` crashes, and the no-op NaN guards.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)