### PR TITLE
lagoon+saloon: fix P1 footguns (cplx reductions, eig rtol)

### DIFF
--- a/lagoon/desk/lib/lagoon.hoon
+++ b/lagoon/desk/lib/lagoon.hoon
@@ -728,6 +728,11 @@
   ::
   ::  Operators
   ::
+  ::  +max/+min (and +argmax/+argmin, which call them) reduce with the kind's
+  ::  %gth/%lth ordering, so they require a TOTALLY ORDERED kind.  On %cplx the
+  ::  ordering op deliberately crashes with 'lagoon: %cplx has no total order;
+  ::  use abs/equ' (the complex numbers have no total order).  +any/+all inherit
+  ::  this, since they read the reduced +max/+min scalar.
   ++  max
     ~/  %max
     |=  a=ray
@@ -1179,6 +1184,8 @@
   ::  all: every element truthy  <=>  the min element is nonzero.
   ::  Read the reduced scalar as the head of its ravel, so this is
   ::  independent of min/max's output shape and works for any rank.
+  ::  Because they reduce via +max/+min, +any/+all need a totally ordered kind
+  ::  and crash on %cplx (see +max) -- test complex rays with +is-close/+equ.
   ++  any
     |=  [a=ray]
     ^-  ?(%.y %.n)

--- a/lagoon/desk/tests/lib/lagoon-compare-reduce.hoon
+++ b/lagoon/desk/tests/lib/lagoon-compare-reduce.hoon
@@ -166,4 +166,15 @@
     %+  expect-eq  !>(%.n)  !>((all:la all-false))
     %+  expect-eq  !>(%.n)  !>((any:la all-false))
   ==
+::  %cplx has no total order: the ordering reductions (max/min, and any/all
+::  which read them) crash via +fun-scalar %gth -> +ord, rather than silently
+::  mis-ordering.  Test complex rays with +is-close/+equ instead.
+++  test-cplx-reduce-crashes  ^-  tang
+  =/  c  (fill:la [shape=~[1 2] bloq=6 kind=%cplx tail=~] 0x3f80.0000)
+  ;:  weld
+    (expect-fail |.((max:la c)))
+    (expect-fail |.((min:la c)))
+    (expect-fail |.((any:la c)))
+    (expect-fail |.((all:la c)))
+  ==
 --

--- a/saloon/desk/lib/saloon.hoon
+++ b/saloon/desk/lib/saloon.hoon
@@ -750,6 +750,10 @@
     =/  cb  bloq.meta.a
     ?>  ?|(=(5 cb) =(6 cb) =(7 cb) =(8 cb))
     =/  rb  (cb-comp cb)
+    ::  rtol: same default + width guard as +eig, against the component (rb).
+    =/  rtol  ?:(=(0x1 `@`rtol) `@r`(feps rb) rtol)
+    ~|  'saloon eig (hermitian): rtol wider than the component; match +sake width to the component bloq'
+    ?>  (^lte (met 3 `@`rtol) (bex (^sub rb 3)))
     ?>  =(2 (lent shape.meta.a))
     =/  n  (snag 0 shape.meta.a)
     ?>  =(n (snag 1 shape.meta.a))
@@ -777,11 +781,11 @@
   ::  (+near/+cnear) -- a matrix symmetric only up to rounding (e.g. a Gram
   ::  matrix from +mmul) is accepted; a genuinely asymmetric one crashes.
   ::
-  ::  CALLERS: set rtol via +sake, and match its WIDTH to the component (@rs for
-  ::  @cs etc.) -- a mismatched width silently mis-scales the threshold.  The
-  ::  bare `sa` default rtol=0x1 is a denormal, not 1.0: it never satisfies the
-  ::  convergence test, so the 60-sweep cap fires and a "~&" warning is emitted
-  ::  (the result is still returned, not silently wrong) -- always call +sake.
+  ::  CALLERS: prefer +sake to set rtol, matched in WIDTH to the component (@rs
+  ::  for @cs etc.).  A tolerance WIDER than the component is now rejected (its
+  ::  high bytes would be dropped, mis-scaling the threshold).  The bare `sa`
+  ::  default rtol=0x1 (a denormal, not 1.0) is replaced by a width-appropriate
+  ::  epsilon (+feps) so bare +eig still converges, though +sake is recommended.
   ::    Examples
   ::      > =sa  (sake %n .~1e-12)
   ::      > =a   (en-ray:la [[~[2 2] 6 %i754 ~] ~[~[.~2 .~1] ~[.~1 .~2]]])  ::  [[2 1] [1 2]]
@@ -794,6 +798,12 @@
     ?:  =(%cplx kind.meta.a)  (eig-herm a)
     =/  b  bloq.meta.a
     ?>  ?|(=(4 b) =(5 b) =(6 b) =(7 b))
+    ::  rtol: replace the unusable bare default (0x1, a denormal) with a width-
+    ::  appropriate epsilon; reject a tolerance wider than the component, whose
+    ::  high bytes would be dropped and silently mis-scale the threshold.
+    =/  rtol  ?:(=(0x1 `@`rtol) `@r`(feps b) rtol)
+    ~|  'saloon eig: rtol wider than the %i754 component; match +sake width to the array bloq'
+    ?>  (^lte (met 3 `@`rtol) (bex (^sub b 3)))
     ?>  =(2 (lent shape.meta.a))
     =/  n  (snag 0 shape.meta.a)
     ?>  =(n (snag 1 shape.meta.a))

--- a/saloon/desk/tests/lib/saloon-eig-tol.hoon
+++ b/saloon/desk/tests/lib/saloon-eig-tol.hoon
@@ -16,4 +16,22 @@
   ^-  ray:ls
   (en-ray:(lake %n) [[~[2 2] 6 %i754 ~] ~[~[.~2 .~1] ~[.~2 .~2]]])
 ++  test-asymmetric-crashes  (expect-fail |.((eigvals:sad a-asym)))
+::  rtol width must match the component.  .~1e-12 is @rd (8 bytes) on an @rs
+::  (bloq 5, 4-byte) array: wider than the component, so its high bytes would
+::  silently mis-scale the threshold -- rejected.  A matching @rs rtol (.1e-6)
+::  is accepted (and yields the two eigenvalues).
+++  a-rs
+  ^-  ray:ls
+  (en-ray:(lake %n) [[~[2 2] 5 %i754 ~] ~[~[.2 .1] ~[.1 .2]]])
+++  test-rtol-width-mismatch-rejected  (expect-fail |.((eigvals:(sake %n .~1e-12) a-rs)))
+++  test-rtol-width-match-ok
+  %-  expect
+  !>  =(2 (lent (ravel:(lake %n) (eigvals:(sake %n .1e-6) a-rs))))
+::  bare `sa` (no +sake): the unusable 0x1 default rtol is replaced by a width-
+::  appropriate +feps, so eig still converges -- here to the same {1,3} as a
+::  +sake-set run, rather than spinning out the 60-sweep cap.
+++  test-bare-eig-converges
+  =/  a  (en-ray:(lake %n) [[~[2 2] 6 %i754 ~] ~[~[.~2 .~1] ~[.~1 .~2]]])
+  %-  expect
+  !>  (all:(lake %n) (is-close:(lake %n) (eigvals:sa a) (eigvals:sad a) [.~1e-6 .~1e-6]))
 --


### PR DESCRIPTION
Three footguns from the Gnome/Angel review triage, in one pass.

### lagoon — ordered-kind reductions on `%cplx`
`+max`/`+min`/`+argmax`/`+argmin` (and `+any`/`+all`, which read them) reduce via the kind's `%gth`/`%lth` ordering, so they crash on `%cplx` (the complex numbers have no total order). The crash is already clean — `+fun-scalar`'s `+ord` raises `'lagoon: %cplx has no total order; use abs/equ'` — so this just **documents** the ordered-kind requirement at those arms.

### saloon `+eig`/`+eig-herm` — unusable bare rtol default
The bare `sa` default `rtol=0x1` is a **denormal**, not `1.0`; it never satisfies the convergence test, so the 60-sweep cap always fires. Replace the `0x1` default with a width-appropriate epsilon (`+feps`) so bare `+eig` still converges.

### saloon `+eig`/`+eig-herm` — rtol width mismatch
An rtol whose width doesn't match the component (e.g. an `@rd` tolerance on an `@rs` array) silently mis-scales the threshold. **Reject** a tolerance wider than the component (its high bytes would be dropped).

### Tests (verified on `~hex`)
- `saloon-eig-tol`: `test-rtol-width-mismatch-rejected`, `test-rtol-width-match-ok`, `test-bare-eig-converges`
- `lagoon-compare-reduce`: `test-cplx-reduce-crashes`
- All pre-existing eig / compare-reduce tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)