### PR TITLE
saloon: default +sa rounding mode to %n (was %z)

### DIFF
--- a/saloon/desk/lib/saloon.hoon
+++ b/saloon/desk/lib/saloon.hoon
@@ -25,7 +25,7 @@
 ::
 ++  sa
   ^|
-  =+  [rnd=*rounding-mode rtol=`@r`0x1]
+  =+  [rnd=`rounding-mode`%n rtol=`@r`0x1]
   ~/  %sa-core
   |%
   ::  innermost core of Saloon functionality


### PR DESCRIPTION
Bare `+sa` took `rnd=*rounding-mode`, but `*rounding-mode` bunts to **%z** (toward zero), not `%n` — so transcendentals and eig on a bare `+sa` rounded toward zero instead of the IEEE/SoftFloat default (round-nearest-even). Surfaced during the `%cplx` work, where bare `exp:sa` disagreed with `sake %n`.

Fix: default `+sa`'s rnd explicitly to `%n`; `+sake` still overrides. All saloon suites (eig, eigh, unum, cplx) and the lagoon suites stay green.

**Note for the jetting work:** the bare `+la` core in `/lib/lagoon` has the same `*rounding-mode → %z` default. Changing *it* is coupled to the `%mod` jet (which reads the door rnd for its quotient): on a runtime whose binary predates the C-fmod jet fix (Vere #1021/#1022), a `%n` default makes `mod` round-to-nearest (`5 mod 3 = −1`) instead of truncating. Left at `%z` here and flagged to fix in lockstep with that jet reaching the runtime — relevant because the Chebyshev jetting work needs `%n` as the universal default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)