### PR TITLE
twoc: two's-complement jets (scalar + Lagoon %int2 arrays)

### DIFF
--- a/lagoon/vere/noun/jets/i/lagoon.c
+++ b/lagoon/vere/noun/jets/i/lagoon.c
@@ -8,6 +8,7 @@
 #include "noun.h"
 #include "softfloat.h"
 #include "softblas.h"
+#include "jets/i/twoc.h"  // shared two's-complement kernels (%int2 array ops)
 
 #include <math.h>  // for pow()
 #include <stdio.h>
@@ -2199,6 +2200,67 @@
     return u3nc(u3nq(u3nt(M_, P_, u3_nul), u3k(bloq), c3__i754, u3_nul), r_data);
   }
 
+/* %int2 element-wise binary op over a ray: native two's-complement per lane
+** (lane width = 2^bloq bits, always a machine width 8..128, so all native --
+** c3_b/s/w/d/__int128).  Mirrors the i754 byte-marshalling (the data atom's
+** leading 0x1 sentinel sits just past the last lane and is preserved).  add/
+** sub/mul are direct typed wraps; div/mod use the shared signed twoc kernels
+** and DECLINE (u3_none -> Hoon, which crashes) on a zero divisor.  Result is
+** the new data atom; the caller re-wraps it with the (unchanged) meta.
+*/
+  typedef enum { _LA_ADD, _LA_SUB, _LA_MUL, _LA_DIV, _LA_REM } _la_iop;
+
+  static u3_noun
+  _la_int2_binop(u3_noun x_data,
+                 u3_noun y_data,
+                 u3_noun shape,
+                 u3_noun bloq,
+                 _la_iop op)
+  {
+    c3_d bl = u3x_atom(bloq);
+    if ( bl < 3 || bl > 7 ) {
+      return u3_none;
+    }
+    c3_d len = _get_length(shape);
+    c3_d lb  = (c3_d)1 << (bl - 3);          // bytes per lane
+    c3_d syz = len * lb;
+    c3_d w   = (c3_d)1 << bl;                // lane width in bits
+
+    c3_y* xb = (c3_y*)u3a_malloc(syz * sizeof(c3_y));
+    c3_y* yb = (c3_y*)u3a_malloc((syz + 1) * sizeof(c3_y));
+    u3r_bytes(0, syz, xb, x_data);
+    u3r_bytes(0, syz + 1, yb, y_data);
+
+#define _LA_EW(TY, MSK, SB, DIVFN, REMFN)                                    \
+  { TY* X = (TY*)xb;  TY* Y = (TY*)yb;                                       \
+    for ( c3_d i = 0; i < len; i++ ) {                                       \
+      switch ( op ) {                                                        \
+        case _LA_ADD: Y[i] = (TY)(X[i] + Y[i]); break;                       \
+        case _LA_SUB: Y[i] = (TY)(X[i] - Y[i]); break;                       \
+        case _LA_MUL: Y[i] = (TY)(X[i] * Y[i]); break;                       \
+        case _LA_DIV:                                                        \
+          if ( 0 == Y[i] ) { u3a_free(xb); u3a_free(yb); return u3_none; }   \
+          Y[i] = (TY)DIVFN(X[i], Y[i], (MSK), (SB)); break;                  \
+        case _LA_REM:                                                        \
+          if ( 0 == Y[i] ) { u3a_free(xb); u3a_free(yb); return u3_none; }   \
+          Y[i] = (TY)REMFN(X[i], Y[i], (MSK), (SB)); break;                  \
+      } } }
+
+    switch ( bl ) {
+      case 3: _LA_EW(c3_b,        _tn_msk64(w),  w - 1, _tn_div64,  _tn_rem64);  break;
+      case 4: _LA_EW(c3_s,        _tn_msk64(w),  w - 1, _tn_div64,  _tn_rem64);  break;
+      case 5: _LA_EW(c3_w,        _tn_msk64(w),  w - 1, _tn_div64,  _tn_rem64);  break;
+      case 6: _LA_EW(c3_d,        _tn_msk64(w),  w - 1, _tn_div64,  _tn_rem64);  break;
+      case 7: _LA_EW(_twoc_u128,  _tn_msk128(w), w - 1, _tn_div128, _tn_rem128); break;
+    }
+#undef _LA_EW
+
+    u3_noun r_data = u3i_bytes((syz + 1) * sizeof(c3_y), yb);
+    u3a_free(xb);
+    u3a_free(yb);
+    return r_data;
+  }
+
   u3_noun
   u3wi_la_add(u3_noun cor)
   {
@@ -2238,6 +2300,12 @@
             u3_noun r_data = u3qi_la_add_i754(x_data, y_data, x_shape, x_bloq);
             if (r_data == u3_none) { return u3_none; }
             return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+
+          case c3__int2: {
+            u3_noun r_data = _la_int2_binop(x_data, y_data, x_shape, x_bloq, _LA_ADD);
+            if (r_data == u3_none) { return u3_none; }
+            return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+          }
 
           default:
             return u3_none;
@@ -2286,6 +2354,12 @@
             if (r_data == u3_none) { return u3_none; }
             return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
 
+          case c3__int2: {
+            u3_noun r_data = _la_int2_binop(x_data, y_data, x_shape, x_bloq, _LA_SUB);
+            if (r_data == u3_none) { return u3_none; }
+            return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+          }
+
           default:
             return u3_none;
         }
@@ -2332,6 +2406,12 @@
             u3_noun r_data = u3qi_la_mul_i754(x_data, y_data, x_shape, x_bloq);
             if (r_data == u3_none) { return u3_none; }
             return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+
+          case c3__int2: {
+            u3_noun r_data = _la_int2_binop(x_data, y_data, x_shape, x_bloq, _LA_MUL);
+            if (r_data == u3_none) { return u3_none; }
+            return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+          }
 
           default:
             return u3_none;
@@ -2380,6 +2460,12 @@
             if (r_data == u3_none) { return u3_none; }
             return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
 
+          case c3__int2: {
+            u3_noun r_data = _la_int2_binop(x_data, y_data, x_shape, x_bloq, _LA_DIV);
+            if (r_data == u3_none) { return u3_none; }
+            return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+          }
+
           default:
             return u3_none;
         }
@@ -2426,6 +2512,12 @@
             u3_noun r_data = u3qi_la_mod_i754(x_data, y_data, x_shape, x_bloq);
             if (r_data == u3_none) { return u3_none; }
             return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+
+          case c3__int2: {
+            u3_noun r_data = _la_int2_binop(x_data, y_data, x_shape, x_bloq, _LA_REM);
+            if (r_data == u3_none) { return u3_none; }
+            return u3nc(u3nq(u3k(x_shape), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+          }
 
           default:
             return u3_none;

--- a/libmath/desk/lib/twoc.hoon
+++ b/libmath/desk/lib/twoc.hoon
@@ -1,3 +1,4 @@
+~%  %non  ..part  ~  :: jet registration; nest non in hex (cf /lib/unum, /lib/math)
 |%
 ::  Two's-complement signed integers, MODULAR (operations wrap mod 2^width
 ::  rather than crashing on overflow -- a deliberate divergence from a
@@ -11,6 +12,7 @@
 ::    width (bex bloq), so the logic is defined once in +twid.
 ::
 ++  twid
+  ~/  %twid
   |_  wid=@
   ::  +len: bit width.  +len-mod: the modulus 2^width.
   ++  len  wid
@@ -42,14 +44,14 @@
   ::  Arithmetic.  Because the low `len` bits of a sum/product are independent
   ::  of sign, the same bit-level add and multiply serve signed and unsigned.
   ::
-  ++  add  |=([a=@ b=@] ^-(@ (mod (^add a b) len-mod)))
+  ++  add  ~/  %add  |=([a=@ b=@] ^-(@ (mod (^add a b) len-mod)))
   ::  +neg: two's-complement negation, ~a + 1 (flip the len bits, add one).
   ::  neg(min) = min (wraps).
-  ++  neg  |=(a=@ ^-(@ (mod +((not 0 len (mod a len-mod))) len-mod)))
-  ++  sub  |=([a=@ b=@] ^-(@ (add a (neg b))))
-  ++  mul  |=([a=@ b=@] ^-(@ (mod (^mul (mod a len-mod) (mod b len-mod)) len-mod)))
+  ++  neg  ~/  %neg  |=(a=@ ^-(@ (mod +((not 0 len (mod a len-mod))) len-mod)))
+  ++  sub  ~/  %sub  |=([a=@ b=@] ^-(@ (add a (neg b))))
+  ++  mul  ~/  %mul  |=([a=@ b=@] ^-(@ (mod (^mul (mod a len-mod) (mod b len-mod)) len-mod)))
   ::  +abs: |a| as a two's-complement value (abs(min) wraps back to min).
-  ++  abs  |=(a=@ ^-(@ ?:(=(1 (msb a)) (neg a) (mod a len-mod))))
+  ++  abs  ~/  %abs  |=(a=@ ^-(@ ?:(=(1 (msb a)) (neg a) (mod a len-mod))))
   ::  +overflow: would a + b overflow a CHECKED signed add?  Retained for
   ::  callers that want to detect rather than wrap; +add no longer uses it.
   ++  overflow
@@ -60,6 +62,7 @@
   ::  +div: signed division, truncating toward zero (C / Hoon `div` style).
   ::  Division by zero crashes (as `div` does).  div(min, -1) wraps to min.
   ++  div
+    ~/  %div
     |=  [a=@ b=@]
     ^-  @
     =/  sa  (msb a)
@@ -70,6 +73,7 @@
   ::  +rem: signed remainder, sign follows the DIVIDEND (C `%` / truncated).
   ::  a == (add (mul (div a b) b) (rem a b)).
   ++  rem
+    ~/  %rem
     |=  [a=@ b=@]
     ^-  @
     =/  r  (mod (abs a) (abs b))
@@ -77,6 +81,7 @@
     (neg r)
   ::  +pow: a to a NON-NEGATIVE integer power n (raw @), by modular squaring.
   ++  pow
+    ~/  %pow
     |=  [a=@ n=@]
     ^-  @
     =/  base  (mod a len-mod)
@@ -94,13 +99,14 @@
     (dec (bex len))
   ::  Comparisons, by two's-complement order (negatives below non-negatives).
   ++  gth
+    ~/  %gth
     |=  [a=@ b=@]
     ?:  =(1 (mix (msb a) (msb b)))
       =(0 (msb a))
     (^gth a b)
-  ++  lth  |=([a=@ b=@] (gth b a))
-  ++  lte  |=([a=@ b=@] !(gth a b))
-  ++  gte  |=([a=@ b=@] !(gth b a))
+  ++  lth  ~/  %lth  |=([a=@ b=@] (gth b a))
+  ++  lte  ~/  %lte  |=([a=@ b=@] !(gth a b))
+  ++  gte  ~/  %gte  |=([a=@ b=@] !(gth b a))
   --
 ::
 ::  +twoc: bloq-keyed facade over +twid (width = 2^bloq).  Logic lives in

--- a/libmath/tools/twoc/README.md
+++ b/libmath/tools/twoc/README.md
@@ -1,0 +1,23 @@
+# `/lib/twoc` jet validation harnesses
+
+Standalone C programs that check the arithmetic in the `/lib/twoc` jet
+(`libmath/vere/noun/jets/i/twoc.c`) against an independent two's-complement
+reference, BEFORE any ship build.  Each copies the jet's arithmetic VERBATIM and
+compares to a from-scratch reference built on hardware `__int128` / `mpz`.
+
+- `twoc_native_test.c` — the native paths (`c3_d` for wid<=64, `__int128` for
+  wid<=128).  Widths 8/16/17/32/64/100, all sign edges (min, -1, max, 0), 12
+  ops.  **8280 checks.**
+- `twoc_gmp_test.c` — the GNU MP path, cross-checked vs the same hardware
+  reference at widths 8..100, plus hand-verified 200-bit cases GMP-only.
+  **5692 checks.**
+
+## Run
+
+```
+cc -O2 -Wall -Wno-unused-function twoc_native_test.c -o /tmp/t && /tmp/t
+cc -O2 -Wall -Wno-unused-function -I/opt/homebrew/include -L/opt/homebrew/lib \
+   twoc_gmp_test.c -lgmp -o /tmp/tg && /tmp/tg
+```
+
+Both print `checks=<N> fails=0` on success.

--- a/libmath/tools/twoc/twoc_gmp_test.c
+++ b/libmath/tools/twoc/twoc_gmp_test.c
@@ -1,0 +1,106 @@
+// Validate the GMP (arbitrary-precision) path of twoc.c.
+// The _tg_* helpers + op blocks are copied VERBATIM from the jet; we run them
+// at widths 8..100 and compare to the independent hardware u128/s128 reference
+// (the same one that validated the native path), then hand-check a few >128
+// cases that no hardware type can hold.
+#include <stdio.h>
+#include <gmp.h>
+
+typedef unsigned long long c3_d;
+typedef unsigned char      c3_t;
+typedef unsigned __int128  u128;
+typedef          __int128  s128;
+#define c3y 0
+#define c3n 1
+
+// ---- VERBATIM helpers from twoc.c ----
+static inline void _tg_mask(mpz_t r, const mpz_t a, c3_d wid){ mpz_fdiv_r_2exp(r,a,wid); }
+static inline c3_t _tg_sign(const mpz_t m, c3_d wid){ return mpz_tstbit(m,wid-1)?c3y:c3n; }
+static inline void _tg_signed(mpz_t s, const mpz_t m, c3_d wid){
+  if ( _tg_sign(m,wid)==c3y ){ mpz_t p; mpz_init(p); mpz_ui_pow_ui(p,2,wid);
+    mpz_sub(s,m,p); mpz_clear(p);
+  } else mpz_set(s,m);
+}
+// ---- op blocks mirroring the jet GMPBLOCKs (operate on in-range inputs) ----
+static void G_add(mpz_t r,mpz_t a,mpz_t b,c3_d w){ mpz_add(r,a,b); _tg_mask(r,r,w); }
+static void G_sub(mpz_t r,mpz_t a,mpz_t b,c3_d w){ mpz_sub(r,a,b); _tg_mask(r,r,w); }
+static void G_mul(mpz_t r,mpz_t a,mpz_t b,c3_d w){ mpz_mul(r,a,b); _tg_mask(r,r,w); }
+static void G_neg(mpz_t r,mpz_t a,c3_d w){ mpz_neg(r,a); _tg_mask(r,r,w); }
+static void G_abs(mpz_t r,mpz_t a,c3_d w){ mpz_t m; mpz_init(m); _tg_mask(m,a,w);
+  if(_tg_sign(m,w)==c3y){ mpz_neg(m,m); _tg_mask(m,m,w);} mpz_set(r,m); mpz_clear(m); }
+static void G_div(mpz_t r,mpz_t a,mpz_t b,c3_d w){ mpz_t am,bm,as,bs;
+  mpz_inits(am,bm,as,bs,NULL); _tg_mask(am,a,w); _tg_mask(bm,b,w);
+  _tg_signed(as,am,w); _tg_signed(bs,bm,w); mpz_tdiv_q(as,as,bs); _tg_mask(as,as,w);
+  mpz_set(r,as); mpz_clears(am,bm,as,bs,NULL); }
+static void G_rem(mpz_t r,mpz_t a,mpz_t b,c3_d w){ mpz_t am,bm,as,bs;
+  mpz_inits(am,bm,as,bs,NULL); _tg_mask(am,a,w); _tg_mask(bm,b,w);
+  _tg_signed(as,am,w); _tg_signed(bs,bm,w); mpz_tdiv_r(as,as,bs); _tg_mask(as,as,w);
+  mpz_set(r,as); mpz_clears(am,bm,as,bs,NULL); }
+static void G_pow(mpz_t r,mpz_t a,c3_d n,c3_d w){ mpz_t am,nm,mod;
+  mpz_inits(am,nm,mod,NULL); _tg_mask(am,a,w); mpz_set_ui(nm,n);
+  mpz_ui_pow_ui(mod,2,w); mpz_powm(am,am,nm,mod); mpz_set(r,am);
+  mpz_clears(am,nm,mod,NULL); }
+static c3_t G_gth(mpz_t a,mpz_t b,c3_d w){ mpz_t as,bs; mpz_inits(as,bs,NULL);
+  _tg_signed(as,a,w); _tg_signed(bs,b,w); int c=mpz_cmp(as,bs);
+  mpz_clears(as,bs,NULL); return c>0?c3y:c3n; }
+
+// ---- independent hardware reference (wid <= 100) ----
+static u128 R_mask(int w){ return (((u128)1)<<w)-1; }
+static s128 R_sgn(u128 p,int w){ p&=R_mask(w);
+  if((p>>(w-1))&1) return (s128)p-(s128)(((u128)1)<<w); return (s128)p; }
+static u128 R_pat(s128 v,int w){ return ((u128)v)&R_mask(w); }
+
+static void u128_to_mpz(mpz_t r,u128 v){ mpz_set_ui(r,(c3_d)(v>>64));
+  mpz_mul_2exp(r,r,64); mpz_t lo; mpz_init_set_ui(lo,(c3_d)v); mpz_add(r,r,lo); mpz_clear(lo); }
+static u128 mpz_to_u128(const mpz_t v){ mpz_t t,lo; mpz_inits(t,lo,NULL);
+  mpz_fdiv_r_2exp(lo,v,64); mpz_fdiv_q_2exp(t,v,64);
+  u128 r=((u128)mpz_get_ui(t)<<64)|(u128)mpz_get_ui(lo); mpz_clears(t,lo,NULL); return r; }
+
+static long long FAILS=0, TOTS=0;
+static void chku(const char*op,int w,u128 got,u128 ref){ TOTS++;
+  if(got!=ref){ FAILS++; if(FAILS<=40)
+    fprintf(stderr,"FAIL %s w=%d got=%llx%016llx ref=%llx%016llx\n",op,w,
+      (c3_d)(got>>64),(c3_d)got,(c3_d)(ref>>64),(c3_d)ref); } }
+
+int main(void){
+  int widths[]={8,16,17,32,64,100};
+  mpz_t a,b,r; mpz_inits(a,b,r,NULL);
+  for(int wi=0;wi<6;wi++){ int w=widths[wi]; u128 m=R_mask(w), half=((u128)1)<<(w-1);
+    u128 vals[]={0,1,2,3,half-1,half,half+1,m-1,m,(u128)5<<(w/2),m/3,(m/7)|half};
+    int NV=12;
+    for(int i=0;i<NV;i++)for(int j=0;j<NV;j++){
+      u128 ua=vals[i]&m, ub=vals[j]&m; u128_to_mpz(a,ua); u128_to_mpz(b,ub);
+      G_add(r,a,b,w); chku("add",w,mpz_to_u128(r),(ua+ub)&m);
+      G_sub(r,a,b,w); chku("sub",w,mpz_to_u128(r),R_pat(R_sgn(ua,w)-R_sgn(ub,w),w));
+      G_mul(r,a,b,w); chku("mul",w,mpz_to_u128(r),(ua*ub)&m);
+      chku("gth",w,G_gth(a,b,w),(R_sgn(ua,w)>R_sgn(ub,w))?c3y:c3n);
+      if((ub&m)!=0){ s128 sa=R_sgn(ua,w),sb=R_sgn(ub,w); s128 q=sa/sb, rr=sa-q*sb;
+        G_div(r,a,b,w); chku("div",w,mpz_to_u128(r),R_pat(q,w));
+        G_rem(r,a,b,w); chku("rem",w,mpz_to_u128(r),R_pat(rr,w)); }
+    }
+    for(int i=0;i<NV;i++){ u128 ua=vals[i]&m; u128_to_mpz(a,ua);
+      G_neg(r,a,w); chku("neg",w,mpz_to_u128(r),R_pat(-R_sgn(ua,w),w));
+      G_abs(r,a,w); chku("abs",w,mpz_to_u128(r),(R_sgn(ua,w)<0)?R_pat(-R_sgn(ua,w),w):(ua&m));
+      c3_d ns[]={0,1,2,3,5,8,13};
+      for(int k=0;k<7;k++){ c3_d n=ns[k]; u128 acc=1&m,base=ua&m;
+        for(c3_d t=0;t<n;t++) acc=(acc*base)&m;
+        G_pow(r,a,n,w); chku("pow",w,mpz_to_u128(r),acc); }
+    }
+  }
+  // hand-checked wide cases (w=200): -1 + -1 = -2; -1 * -1 = 1; min/-1 = min; max+1 = min
+  { c3_d w=200; mpz_t one,negone,res,exp; mpz_inits(one,negone,res,exp,NULL);
+    mpz_set_ui(one,1); _tg_mask(negone,/*=-1 as 2^w-1*/ negone,w);
+    mpz_ui_pow_ui(negone,2,w); mpz_sub_ui(negone,negone,1);   // 2^200 - 1 == -1
+    G_add(res,negone,negone,w); mpz_ui_pow_ui(exp,2,w); mpz_sub_ui(exp,exp,2);
+    TOTS++; if(mpz_cmp(res,exp)!=0){FAILS++; fprintf(stderr,"FAIL wide add -1+-1\n");}
+    G_mul(res,negone,negone,w); TOTS++; if(mpz_cmp_ui(res,1)!=0){FAILS++; fprintf(stderr,"FAIL wide mul -1*-1\n");}
+    mpz_t mn; mpz_init(mn); mpz_ui_pow_ui(mn,2,w-1);          // min = 2^199
+    G_div(res,mn,negone,w); TOTS++; if(mpz_cmp(res,mn)!=0){FAILS++; fprintf(stderr,"FAIL wide div min/-1\n");}
+    mpz_t mx; mpz_init(mx); mpz_ui_pow_ui(mx,2,w-1); mpz_sub_ui(mx,mx,1); // max=2^199-1
+    G_add(res,mx,one,w); TOTS++; if(mpz_cmp(res,mn)!=0){FAILS++; fprintf(stderr,"FAIL wide max+1\n");}
+    mpz_clears(one,negone,res,exp,mn,mx,NULL);
+  }
+  mpz_clears(a,b,r,NULL);
+  printf("checks=%lld fails=%lld\n",TOTS,FAILS);
+  return FAILS?1:0;
+}

--- a/libmath/tools/twoc/twoc_native_test.c
+++ b/libmath/tools/twoc/twoc_native_test.c
@@ -1,0 +1,156 @@
+// Standalone validation of the native arithmetic in twoc.c.
+// Copies the _TWOC_NATIVE macro + mask helpers VERBATIM from the jet, and
+// checks them against an independent two's-complement reference (u128/s128).
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef unsigned long long c3_d;
+typedef unsigned char      c3_t;
+typedef unsigned __int128  _twoc_u128;
+typedef          __int128  _twoc_s128;
+#define c3y 0
+#define c3n 1
+
+// ---- VERBATIM from twoc.c ----
+#define _TWOC_NATIVE(SUF, UT)                                                  \
+  static inline UT _tn_neg##SUF(UT a, UT msk) {                                \
+    return (UT)(((~a) + 1) & msk);                                             \
+  }                                                                            \
+  static inline UT _tn_sign##SUF(UT a, c3_d sb) {                              \
+    return (UT)((a >> sb) & 1);                                               \
+  }                                                                            \
+  static inline UT _tn_abs##SUF(UT a, UT msk, c3_d sb) {                       \
+    return _tn_sign##SUF(a, sb) ? _tn_neg##SUF(a, msk) : (UT)(a & msk);        \
+  }                                                                            \
+  static inline UT _tn_add##SUF(UT a, UT b, UT msk) {                          \
+    return (UT)((a + b) & msk);                                                \
+  }                                                                            \
+  static inline UT _tn_sub##SUF(UT a, UT b, UT msk) {                          \
+    return (UT)((a + _tn_neg##SUF(b, msk)) & msk);                             \
+  }                                                                            \
+  static inline UT _tn_mul##SUF(UT a, UT b, UT msk) {                          \
+    return (UT)(((a & msk) * (b & msk)) & msk);                                \
+  }                                                                            \
+  static inline UT _tn_div##SUF(UT a, UT b, UT msk, c3_d sb) {                 \
+    UT qa = _tn_abs##SUF(a, msk, sb), qb = _tn_abs##SUF(b, msk, sb);           \
+    UT q  = (UT)(qa / qb);                                                     \
+    return ( _tn_sign##SUF(a, sb) != _tn_sign##SUF(b, sb) )                    \
+           ? _tn_neg##SUF(q, msk) : (UT)(q & msk);                            \
+  }                                                                            \
+  static inline UT _tn_rem##SUF(UT a, UT b, UT msk, c3_d sb) {                 \
+    UT r = (UT)(_tn_abs##SUF(a, msk, sb) % _tn_abs##SUF(b, msk, sb));          \
+    return _tn_sign##SUF(a, sb) ? _tn_neg##SUF(r, msk) : (UT)(r & msk);        \
+  }                                                                            \
+  static inline UT _tn_pow##SUF(UT a, c3_d n, UT msk) {                        \
+    UT base = (UT)(a & msk), acc = (UT)(1 & msk);                              \
+    while ( n ) {                                                              \
+      if ( n & 1 ) acc = (UT)((acc * base) & msk);                            \
+      base = (UT)((base * base) & msk);                                        \
+      n >>= 1;                                                                 \
+    }                                                                          \
+    return acc;                                                               \
+  }                                                                            \
+  static inline c3_t _tn_gth##SUF(UT a, UT b, c3_d sb) {                       \
+    UT sa = _tn_sign##SUF(a, sb), sbb = _tn_sign##SUF(b, sb);                  \
+    if ( sa != sbb ) return ( 0 == sa ) ? c3y : c3n;                          \
+    return ( a > b ) ? c3y : c3n;                                             \
+  }
+
+_TWOC_NATIVE(64,  c3_d)
+_TWOC_NATIVE(128, _twoc_u128)
+
+static inline c3_d _tn_msk64(c3_d wid) {
+  return ( wid >= 64 ) ? (c3_d)~0ull : (((c3_d)1 << wid) - 1);
+}
+static inline _twoc_u128 _tn_msk128(c3_d wid) {
+  return ( wid >= 128 ) ? (~(_twoc_u128)0) : ((((_twoc_u128)1) << wid) - 1);
+}
+static inline c3_t _twoc_not(c3_t b) { return ( c3y == b ) ? c3n : c3y; }
+// ---- end verbatim ----
+
+typedef unsigned __int128 u128;
+typedef          __int128 s128;
+
+// reference (wid <= 100 so modv fits u128 and signed fits s128)
+static u128 R_mask(int w){ return (((u128)1) << w) - 1; }
+static s128 R_sgn(u128 p, int w){
+  u128 m = R_mask(w);
+  p &= m;
+  if ( (p >> (w-1)) & 1 ) return (s128)p - (s128)(((u128)1) << w);
+  return (s128)p;
+}
+static u128 R_pat(s128 v, int w){ return ((u128)v) & R_mask(w); }
+
+static long long FAILS = 0, TOTS = 0;
+static void chk(const char* op, int w, u128 a, u128 b, u128 got, u128 ref){
+  TOTS++;
+  if ( got != ref ) {
+    FAILS++;
+    if ( FAILS <= 40 ) {
+      fprintf(stderr, "FAIL %s w=%d a=%016llx%016llx b=%016llx%016llx got=%016llx%016llx ref=%016llx%016llx\n",
+        op, w, (c3_d)(a>>64),(c3_d)a, (c3_d)(b>>64),(c3_d)b,
+        (c3_d)(got>>64),(c3_d)got, (c3_d)(ref>>64),(c3_d)ref);
+    }
+  }
+}
+
+// dispatch wrappers
+static u128 J_add(u128 a,u128 b,int w){ return w<=64? _tn_add64(a,b,_tn_msk64(w)) : _tn_add128(a,b,_tn_msk128(w)); }
+static u128 J_sub(u128 a,u128 b,int w){ return w<=64? _tn_sub64(a,b,_tn_msk64(w)) : _tn_sub128(a,b,_tn_msk128(w)); }
+static u128 J_mul(u128 a,u128 b,int w){ return w<=64? _tn_mul64(a,b,_tn_msk64(w)) : _tn_mul128(a,b,_tn_msk128(w)); }
+static u128 J_div(u128 a,u128 b,int w){ return w<=64? _tn_div64(a,b,_tn_msk64(w),w-1) : _tn_div128(a,b,_tn_msk128(w),w-1); }
+static u128 J_rem(u128 a,u128 b,int w){ return w<=64? _tn_rem64(a,b,_tn_msk64(w),w-1) : _tn_rem128(a,b,_tn_msk128(w),w-1); }
+static u128 J_neg(u128 a,int w){ return w<=64? _tn_neg64(a,_tn_msk64(w)) : _tn_neg128(a,_tn_msk128(w)); }
+static u128 J_abs(u128 a,int w){ return w<=64? _tn_abs64(a,_tn_msk64(w),w-1) : _tn_abs128(a,_tn_msk128(w),w-1); }
+static c3_t J_gth(u128 a,u128 b,int w){ return w<=64? _tn_gth64(a,b,w-1) : _tn_gth128(a,b,w-1); }
+static u128 J_pow(u128 a,c3_d n,int w){ return w<=64? _tn_pow64(a,n,_tn_msk64(w)) : _tn_pow128(a,n,_tn_msk128(w)); }
+
+int main(void){
+  int widths[] = {8,16,17,32,64,100};
+  for ( int wi=0; wi<6; wi++ ){
+    int w = widths[wi];
+    u128 m = R_mask(w);
+    u128 half = ((u128)1) << (w-1);
+    u128 vals[] = { 0,1,2,3, half-1, half, half+1, m-1, m, (u128)5<<(w/2), m/3, (m/7)|half };
+    int NV = sizeof(vals)/sizeof(vals[0]);
+    for ( int i=0;i<NV;i++ ) for ( int j=0;j<NV;j++ ){
+      u128 a=vals[i]&m, b=vals[j]&m;
+      // add/sub/mul
+      chk("add",w,a,b, J_add(a,b,w), (a+b)&m);
+      chk("sub",w,a,b, J_sub(a,b,w), R_pat(R_sgn(a,w)-R_sgn(b,w),w));
+      chk("mul",w,a,b, J_mul(a,b,w), (a*b)&m);
+      // gth as 0/1 mapped: J returns c3y(0)/c3n(1); ref bool
+      c3_t jg = J_gth(a,b,w);
+      u128 rg = (R_sgn(a,w) > R_sgn(b,w)) ? c3y : c3n;
+      chk("gth",w,a,b, jg, rg);
+      c3_t jl = J_gth(b,a,w);
+      chk("lth",w,a,b, jl, (R_sgn(a,w) < R_sgn(b,w))?c3y:c3n);
+      chk("lte",w,a,b, _twoc_not(J_gth(a,b,w)), (R_sgn(a,w) <= R_sgn(b,w))?c3y:c3n);
+      chk("gte",w,a,b, _twoc_not(J_gth(b,a,w)), (R_sgn(a,w) >= R_sgn(b,w))?c3y:c3n);
+      // div/rem (skip zero divisor)
+      if ( (b&m) != 0 ){
+        s128 sa=R_sgn(a,w), sb=R_sgn(b,w);
+        s128 q = sa / sb;            // trunc toward zero
+        s128 r = sa - q*sb;
+        chk("div",w,a,b, J_div(a,b,w), R_pat(q,w));
+        chk("rem",w,a,b, J_rem(a,b,w), R_pat(r,w));
+      }
+    }
+    // unary + pow
+    for ( int i=0;i<NV;i++ ){
+      u128 a=vals[i]&m;
+      chk("neg",w,a,0, J_neg(a,w), R_pat(-R_sgn(a,w),w));
+      chk("abs",w,a,0, J_abs(a,w), (R_sgn(a,w)<0)? R_pat(-R_sgn(a,w),w) : (a&m));
+      c3_d ns[]={0,1,2,3,5,8,13};
+      for ( int k=0;k<7;k++ ){
+        c3_d n=ns[k];
+        // independent reference pow: naive repeated multiply, a^n mod 2^w
+        u128 acc=1&m, base=a&m;
+        for ( c3_d t=0; t<n; t++ ) acc=(acc*base)&m;
+        chk("pow",w,a,n, J_pow(a,n,w), acc);
+      }
+    }
+  }
+  printf("checks=%lld fails=%lld\n", TOTS, FAILS);
+  return FAILS ? 1 : 0;
+}

--- a/libmath/vere/README-twoc.md
+++ b/libmath/vere/README-twoc.md
@@ -1,0 +1,89 @@
+# `/lib/twoc` jets — vere reference
+
+Reference (master) copy of the hand-maintained C jet source for the
+two's-complement integer (`/lib/twoc`) jets, mirrored by hand into the vere
+runtime.  Unlike `/lib/unum` (SoftUnum) or Lagoon (SoftBLAS), `/lib/twoc` needs
+**no vendored library** — the arithmetic is plain integer C plus GNU MP, and
+GMP is already vendored (`ext/gmp`) and linked into `pkg/noun`.
+
+## What is jetted
+
+`/lib/twoc` keeps all its logic in ONE width-keyed door `++twid` (`|_ wid=@`);
+the bloq-keyed `++twoc` facade just re-exports `twid` gates at width
+`(bex bloq)`.  So we register a SINGLE `%twid` core and **every** caller fires
+through it:
+
+- `/lib/fixed`            — `twid:twoc` directly, at arbitrary widths `a+b+1`.
+- `/lib/unum`, Lagoon `%int2` — via the `twoc` facade (bloq → `bex bloq`).
+
+First pass jets the 12 hot-path arms Lagoon `%int2` drives element-wise:
+`add sub neg mul div rem pow abs gth lth lte gte`.  (`msb`, `s-to-twoc`,
+`twoc-to-s` are a planned second pass.)
+
+`wid` is read from the door sample at gate axis 30 (gate axis 7 = door, door
+axis 6 = `wid`), the same shape `unum.c` uses for `bloq`.
+
+## Dispatch: native c3 types vs GNU MP
+
+| `wid`        | path                              |
+|--------------|-----------------------------------|
+| `wid <= 64`  | native `c3_d` (uint64), masked    |
+| `wid <= 128` | native `unsigned __int128`, masked|
+| `wid  > 128` | GNU MP (`mpz`), masked to `wid`   |
+
+The power-of-two bloq widths (8/16/32/64/128 for bloq 3..7) all land in the
+native paths; GMP is the exact backstop for genuinely arbitrary precision. All
+native arithmetic is unsigned with explicit masking, so there is no
+signed-overflow UB (`div(min,-1)` wraps to `min`, matching the Hoon).
+
+## Declining to Hoon (bit-exactness for free)
+
+The jet returns `u3_none` (pure-Hoon arm runs) when:
+
+- an operand does not fit in `wid` bits (`u3r_met(0,x) > wid`) — the Hoon
+  derives sign from raw bit-width (`xeb`), which diverges from masking only
+  off-contract; declining keeps us bit-exact without replicating `xeb` edges.
+- a divisor is zero in `div`/`rem` — the Hoon `div`/`rem` crash; we let them
+  (and avoid a native `SIGFPE` in the serf).
+
+## Validation
+
+Standalone, before any ship build (`libmath/tools/twoc/`): the jet's arithmetic
+is copied verbatim and checked against an independent two's-complement reference
+on hardware `__int128`/`mpz` — `twoc_native_test.c` (native paths, 8280 checks,
+widths 8/16/17/32/64/100, all sign edges) and `twoc_gmp_test.c` (GMP
+cross-checked vs the hardware reference at widths 8..100 plus hand-verified
+200-bit cases, 5692 checks).  Both pass.
+
+On a live hoon-135 fakezod the `twid` jet FIRES bit-exactly through both call
+paths, proven two ways: (1) a sentinel `+1` planted in the native `add` showed
+`1` for jetted `add(0,0)` via BOTH `twid:twoc` (direct) and `twoc:twoc` (facade,
+bloq 3 & 6), `0` interpreted — so a single `%twid` registration fires for both
+callers; (2) timing the identical loop with vs without the hint: `twid`-direct
+1M add-64 = 2.85 s interpreted → 0.87 s jetted (~3.3x); `twoc`-facade is ~1.75x
+(the facade re-instantiates the door per call).  The modest margin is expected:
+the interpreted arm is `(mod (^add a b) (bex wid))` and `^add`/`bex`/`mod` are
+already jetted, so the jet collapses 3 dispatches + glue into 1 + native rather
+than replacing interpreted bignum math.  Bigger wins need wide widths or
+array-level jetting (one C call per `%int2` array op).
+
+## Deltas to apply in vere (not full copies — see the vere branch/PR)
+
+- `pkg/noun/jets/i/twoc.c` — this file (master copy lives in numerics).
+- `pkg/noun/build.zig` — add `jets/i/twoc.c` to the noun sources (next to
+  `jets/i/unum.c`).  No new `linkLibrary` — GMP is already linked.
+- `pkg/noun/jets/w.h`, `q.h` — declare `u3wi_twid_*` / `u3qi_twid_*` (binops &
+  comparisons `(c3_d,u3_atom,u3_atom)`, unary `(c3_d,u3_atom)`).
+- `pkg/noun/jets/135/tree.c` — register a `twid` core under `non` (sibling of
+  `unum`/`math`/`lagoon`): `{ "twid", 7, 0, _135_non__twid_d, no_hashes }`,
+  with `_135_non__twid_<arm>_a[] = {{".2", u3wi_twid_<arm>}, {}}` and
+  `_135_non__twid_d[]` listing the 12 arms at axis 7.  hoon-135 only (lowest
+  shipped kelvin), as with unum.
+
+## Hoon side (`libmath/desk/lib/twoc.hoon`)
+
+Jet-hinted to match: `~% %non ..part ~` on the file core, `~/ %twid` on
+`++twid`, and `~/ %<arm>` on each of the 12 jetted arms.  The `++twoc` facade is
+left unhinted — it re-exports `twid` gates, which already carry the
+registration, so a single `%twid` jet fires for both call paths.  (Verify by
+FIRING, not by jet count.)

--- a/libmath/vere/noun/jets/i/twoc.c
+++ b/libmath/vere/noun/jets/i/twoc.c
@@ -1,0 +1,290 @@
+/// @file
+///
+/// Jets for the numerics `/lib/twoc` library: two's-complement signed integer
+/// arithmetic, MODULAR (operations wrap mod 2^width rather than crashing on
+/// overflow).  Userspace, registered under the `non` chapter alongside `math`,
+/// `lagoon`, and `unum`.  Jet output is bit-identical to the unjetted Hoon.
+///
+/// `/lib/twoc` defines all its logic in ONE width-keyed door `++twid`
+/// (`|_ wid=@`); the bloq-keyed `++twoc` facade just re-exports `twid` gates at
+/// width `(bex bloq)`.  So we register a SINGLE `%twid` core and every caller --
+/// `twid`-direct (`/lib/fixed`) and via the `twoc` facade (`/lib/unum`, Lagoon
+/// `%int2`) -- dispatches here.  We read `wid` from the door sample (gate axis
+/// 7 = door, door axis 6 = `wid`, so wid at gate axis 30; same shape `unum`
+/// uses for `bloq`).
+///
+/// DISPATCH on `wid`:
+///   - wid <= 64   : native c3_d (uint64), masked to wid bits.
+///   - wid <= 128  : native unsigned __int128, masked to wid bits.
+///   - wid  > 128  : GNU MP (mpz), masked to wid bits.
+/// The power-of-two bloq widths (8/16/32/64/128 for bloq 3..7) all land in the
+/// native paths; GMP is the exact backstop for genuinely arbitrary precision.
+///
+/// We DECLINE (return u3_none, so the pure-Hoon arm runs) when:
+///   - any operand does not fit in wid bits (u3r_met(0,x) > wid) -- the Hoon
+///     determines sign from the raw bit-width (xeb), which diverges from naive
+///     masking only off the contract; declining keeps us bit-exact for free.
+///   - a divisor is zero in div/rem -- the Hoon `div`/`rem` crash; let it.
+///
+/// MASTER COPY lives in urbit/numerics libmath/vere/noun/jets/i/twoc.c; applied
+/// by hand to the vere runtime.  GMP is already vendored (ext/gmp) and linked
+/// into pkg/noun.
+
+#include "jets/q.h"
+#include "jets/w.h"
+#include "noun.h"
+#include "jets/i/twoc.h"   // shared native + GMP two's-complement kernels
+
+//  wid from the twid door sample: gate axis 7 = door, door axis 6 = wid.
+#define _TWOC_WID_AXIS 30
+
+//  Read wid (the door sample) from a gate core; c3n if absent/not-atom.
+static inline c3_t
+_twoc_wid(u3_noun cor, c3_d* out)
+{
+  u3_noun w = u3r_at(_TWOC_WID_AXIS, cor);
+  if ( u3_none == w || c3n == u3ud(w) ) {
+    return c3n;
+  }
+  *out = u3r_chub(0, w);
+  return c3y;
+}
+
+//  Does atom [a] fit in [wid] bits?  (Operands wider than wid are out of
+//  contract; the Hoon's xeb-based sign detection would diverge from masking,
+//  so we decline and let the Hoon run.)
+static inline c3_t
+_twoc_fits(u3_atom a, c3_d wid)
+{
+  return ( (c3_d)u3r_met(0, a) <= wid ) ? c3y : c3n;
+}
+
+//  loobean negation (c3y == 0, c3n == 1; C's ! would invert the convention).
+static inline c3_t
+_twoc_not(c3_t b)
+{
+  return ( c3y == b ) ? c3n : c3y;
+}
+
+//  read a wid<=128 operand (one or two chubs) into a __int128.
+static inline _twoc_u128
+_tn_rd128(u3_atom a)
+{
+  return ( ((_twoc_u128)u3r_chub(1, a)) << 64 ) | (_twoc_u128)u3r_chub(0, a);
+}
+
+//  emit a wid<=128 result (two chubs; u3i_chubs strips high zeros).
+static inline u3_noun
+_tn_em128(_twoc_u128 r)
+{
+  c3_d buf[2];
+  buf[0] = (c3_d)r;
+  buf[1] = (c3_d)(r >> 64);
+  return u3i_chubs(2, buf);
+}
+
+/* ----------------------------------------------------------------------------
+** Per-arm cores and wrappers.  Each wrapper extracts the sample, validates
+** atoms, reads wid, applies the fits-guard, and dispatches to the core.
+** -------------------------------------------------------------------------- */
+
+//  binary op: (wid, a, b) -> @.  [g64]/[g128] are native; [gmp] block runs for
+//  wid>128 and must set the result noun [res].
+#define _TWOC_BINOP(nam, e64, e128, GMPBLOCK)                                  \
+  u3_noun u3qi_twid_##nam(c3_d wid, u3_atom a, u3_atom b) {                     \
+    if ( c3n == _twoc_fits(a, wid) || c3n == _twoc_fits(b, wid) ) {            \
+      return u3_none;                                                          \
+    }                                                                          \
+    if ( wid <= 64 ) {                                                         \
+      c3_d msk = _tn_msk64(wid), ua = u3r_chub(0, a), ub = u3r_chub(0, b);     \
+      c3_d r = (e64);  return u3i_chubs(1, &r);                                \
+    }                                                                          \
+    if ( wid <= 128 ) {                                                        \
+      _twoc_u128 msk = _tn_msk128(wid), ua = _tn_rd128(a), ub = _tn_rd128(b);  \
+      _twoc_u128 r = (e128);  return _tn_em128(r);                             \
+    }                                                                          \
+    { u3_noun res;  mpz_t am, bm;                                              \
+      u3r_mp(am, a);  u3r_mp(bm, b);                                           \
+      GMPBLOCK                                                                 \
+      return res;                                                              \
+    }                                                                          \
+  }                                                                            \
+  u3_noun u3wi_twid_##nam(u3_noun cor) {                                       \
+    u3_noun a, b;  c3_d wid;                                                   \
+    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0) ||              \
+         c3n == u3ud(a) || c3n == u3ud(b) ) return u3m_bail(c3__exit);         \
+    if ( c3n == _twoc_wid(cor, &wid) ) return u3_none;                         \
+    return u3qi_twid_##nam(wid, a, b);                                         \
+  }
+
+//  binary comparison: (wid, a, b) -> ?.  [c64]/[c128] native loobeans; GMP
+//  block sets c3_t [v] from signed mpz compare.
+#define _TWOC_CMP(nam, c64, c128, GMPCMP)                                      \
+  u3_noun u3qi_twid_##nam(c3_d wid, u3_atom a, u3_atom b) {                     \
+    if ( c3n == _twoc_fits(a, wid) || c3n == _twoc_fits(b, wid) ) {            \
+      return u3_none;                                                          \
+    }                                                                          \
+    if ( wid <= 64 ) {                                                         \
+      c3_d sb = wid - 1, ua = u3r_chub(0, a), ub = u3r_chub(0, b);             \
+      return (c64);                                                            \
+    }                                                                          \
+    if ( wid <= 128 ) {                                                        \
+      c3_d sb = wid - 1;  _twoc_u128 ua = _tn_rd128(a), ub = _tn_rd128(b);     \
+      return (c128);                                                           \
+    }                                                                          \
+    { c3_t v;  mpz_t am, bm, as, bs;                                           \
+      u3r_mp(am, a);  u3r_mp(bm, b);                                           \
+      mpz_init(as);  mpz_init(bs);                                             \
+      _tg_signed(as, am, wid);  _tg_signed(bs, bm, wid);                       \
+      v = (GMPCMP) ? c3y : c3n;                                                \
+      mpz_clear(am); mpz_clear(bm); mpz_clear(as); mpz_clear(bs);              \
+      return v;                                                                \
+    }                                                                          \
+  }                                                                            \
+  u3_noun u3wi_twid_##nam(u3_noun cor) {                                       \
+    u3_noun a, b;  c3_d wid;                                                   \
+    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0) ||              \
+         c3n == u3ud(a) || c3n == u3ud(b) ) return u3m_bail(c3__exit);         \
+    if ( c3n == _twoc_wid(cor, &wid) ) return u3_none;                         \
+    return u3qi_twid_##nam(wid, a, b);                                         \
+  }
+
+//  unary op: (wid, a) -> @.
+#define _TWOC_UNOP(nam, e64, e128, GMPBLOCK)                                   \
+  u3_noun u3qi_twid_##nam(c3_d wid, u3_atom a) {                                \
+    if ( c3n == _twoc_fits(a, wid) ) return u3_none;                           \
+    if ( wid <= 64 ) {                                                         \
+      c3_d msk = _tn_msk64(wid), sb = wid - 1, ua = u3r_chub(0, a);            \
+      c3_d r = (e64);  (void)sb;  return u3i_chubs(1, &r);                     \
+    }                                                                          \
+    if ( wid <= 128 ) {                                                        \
+      _twoc_u128 msk = _tn_msk128(wid);  c3_d sb = wid - 1;                    \
+      _twoc_u128 ua = _tn_rd128(a);                                            \
+      _twoc_u128 r = (e128);  (void)sb;  return _tn_em128(r);                  \
+    }                                                                          \
+    { u3_noun res;  mpz_t am;                                                  \
+      u3r_mp(am, a);                                                           \
+      GMPBLOCK                                                                 \
+      return res;                                                              \
+    }                                                                          \
+  }                                                                            \
+  u3_noun u3wi_twid_##nam(u3_noun cor) {                                       \
+    u3_noun a = u3r_at(u3x_sam, cor);  c3_d wid;                               \
+    if ( u3_none == a || c3n == u3ud(a) ) return u3m_bail(c3__exit);           \
+    if ( c3n == _twoc_wid(cor, &wid) ) return u3_none;                         \
+    return u3qi_twid_##nam(wid, a);                                            \
+  }
+
+//  add / sub / mul -- pure modular, GMP via add/sub/mul then mask.
+_TWOC_BINOP(add, _tn_add64(ua, ub, msk), _tn_add128(ua, ub, msk),
+  { mpz_add(am, am, bm);  _tg_mask(am, am, wid);
+    mpz_clear(bm);  res = u3i_mp(am); })
+_TWOC_BINOP(sub, _tn_sub64(ua, ub, msk), _tn_sub128(ua, ub, msk),
+  { mpz_sub(am, am, bm);  _tg_mask(am, am, wid);
+    mpz_clear(bm);  res = u3i_mp(am); })
+_TWOC_BINOP(mul, _tn_mul64(ua, ub, msk), _tn_mul128(ua, ub, msk),
+  { mpz_mul(am, am, bm);  _tg_mask(am, am, wid);
+    mpz_clear(bm);  res = u3i_mp(am); })
+
+/* ++div / ++rem:pp -- signed, truncating toward zero (C-style); the remainder's
+** sign follows the DIVIDEND.  A zero divisor crashes the Hoon (`div`/`rem`),
+** so we DECLINE (u3_none) and let the Hoon bail -- in every path, including
+** native, where `qa / qb` with qb==0 would otherwise SIGFPE the serf.
+*/
+#define _TWOC_DIVREM(nam, e64, e128, GMPDIVR)                                  \
+  u3_noun u3qi_twid_##nam(c3_d wid, u3_atom a, u3_atom b) {                     \
+    if ( c3n == _twoc_fits(a, wid) || c3n == _twoc_fits(b, wid) ) {            \
+      return u3_none;                                                          \
+    }                                                                          \
+    if ( wid <= 64 ) {                                                         \
+      c3_d msk = _tn_msk64(wid), ua = u3r_chub(0, a), ub = u3r_chub(0, b);     \
+      if ( 0 == (ub & msk) ) return u3_none;          /* zero divisor */       \
+      c3_d r = (e64);  return u3i_chubs(1, &r);                                \
+    }                                                                          \
+    if ( wid <= 128 ) {                                                        \
+      _twoc_u128 msk = _tn_msk128(wid), ua = _tn_rd128(a), ub = _tn_rd128(b);  \
+      if ( 0 == (ub & msk) ) return u3_none;                                   \
+      _twoc_u128 r = (e128);  return _tn_em128(r);                             \
+    }                                                                          \
+    { mpz_t am, bm, as, bs;                                                    \
+      u3r_mp(am, a);  u3r_mp(bm, b);                                           \
+      _tg_mask(am, am, wid);  _tg_mask(bm, bm, wid);                           \
+      if ( 0 == mpz_sgn(bm) ) {                       /* zero divisor */       \
+        mpz_clear(am);  mpz_clear(bm);  return u3_none;                        \
+      }                                                                        \
+      mpz_init(as);  mpz_init(bs);                                             \
+      _tg_signed(as, am, wid);  _tg_signed(bs, bm, wid);                       \
+      GMPDIVR                                                                  \
+      _tg_mask(as, as, wid);                                                   \
+      mpz_clear(am);  mpz_clear(bm);  mpz_clear(bs);                           \
+      return u3i_mp(as);                                                       \
+    }                                                                          \
+  }                                                                            \
+  u3_noun u3wi_twid_##nam(u3_noun cor) {                                       \
+    u3_noun a, b;  c3_d wid;                                                   \
+    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &b, 0) ||              \
+         c3n == u3ud(a) || c3n == u3ud(b) ) return u3m_bail(c3__exit);         \
+    if ( c3n == _twoc_wid(cor, &wid) ) return u3_none;                         \
+    return u3qi_twid_##nam(wid, a, b);                                         \
+  }
+
+_TWOC_DIVREM(div, _tn_div64(ua, ub, msk, wid - 1), _tn_div128(ua, ub, msk, wid - 1),
+             mpz_tdiv_q(as, as, bs);)
+_TWOC_DIVREM(rem, _tn_rem64(ua, ub, msk, wid - 1), _tn_rem128(ua, ub, msk, wid - 1),
+             mpz_tdiv_r(as, as, bs);)
+
+//  comparisons -- two's-complement order.
+_TWOC_CMP(gth, _tn_gth64(ua, ub, sb), _tn_gth128(ua, ub, sb), mpz_cmp(as, bs) > 0)
+_TWOC_CMP(lth, _tn_gth64(ub, ua, sb), _tn_gth128(ub, ua, sb), mpz_cmp(as, bs) < 0)
+_TWOC_CMP(lte, _twoc_not(_tn_gth64(ua, ub, sb)), _twoc_not(_tn_gth128(ua, ub, sb)),
+          mpz_cmp(as, bs) <= 0)
+_TWOC_CMP(gte, _twoc_not(_tn_gth64(ub, ua, sb)), _twoc_not(_tn_gth128(ub, ua, sb)),
+          mpz_cmp(as, bs) >= 0)
+
+//  neg / abs -- unary.
+_TWOC_UNOP(neg, _tn_neg64(ua, msk), _tn_neg128(ua, msk),
+  { mpz_neg(am, am);  _tg_mask(am, am, wid);  res = u3i_mp(am); })
+_TWOC_UNOP(abs, _tn_abs64(ua, msk, sb), _tn_abs128(ua, msk, sb),
+  { mpz_t m;  mpz_init(m);  _tg_mask(m, am, wid);
+    if ( _tg_sign(m, wid) == c3y ) { mpz_neg(m, m);  _tg_mask(m, m, wid); }
+    mpz_clear(am);  res = u3i_mp(m); })
+
+/* ++pow:pp -- a ^ n, n a NON-NEGATIVE raw integer (read as a plain chub for the
+** native paths; full mpz for GMP).  We decline a >64-bit exponent on the native
+** paths (absurd loop count) and let the Hoon run.
+*/
+  u3_noun
+  u3qi_twid_pow(c3_d wid, u3_atom a, u3_atom n)
+  {
+    if ( c3n == _twoc_fits(a, wid) ) return u3_none;
+    if ( wid <= 128 && (c3_d)u3r_met(0, n) > 64 ) return u3_none;
+    if ( wid <= 64 ) {
+      c3_d msk = _tn_msk64(wid), ua = u3r_chub(0, a), en = u3r_chub(0, n);
+      c3_d r = _tn_pow64(ua, en, msk);
+      return u3i_chubs(1, &r);
+    }
+    if ( wid <= 128 ) {
+      _twoc_u128 msk = _tn_msk128(wid), ua = _tn_rd128(a);
+      c3_d en = u3r_chub(0, n);
+      _twoc_u128 r = _tn_pow128(ua, en, msk);
+      return _tn_em128(r);
+    }
+    { u3_noun res;  mpz_t am, nm, mod;
+      u3r_mp(am, a);  u3r_mp(nm, n);
+      mpz_init(mod);  mpz_ui_pow_ui(mod, 2, wid);
+      _tg_mask(am, am, wid);
+      mpz_powm(am, am, nm, mod);                     /* a^n mod 2^wid */
+      mpz_clear(nm);  mpz_clear(mod);
+      res = u3i_mp(am);
+      return res;
+    }
+  }
+  u3_noun
+  u3wi_twid_pow(u3_noun cor)
+  {
+    u3_noun a, n;  c3_d wid;
+    if ( c3n == u3r_mean(cor, u3x_sam_2, &a, u3x_sam_3, &n, 0) ||
+         c3n == u3ud(a) || c3n == u3ud(n) ) return u3m_bail(c3__exit);
+    if ( c3n == _twoc_wid(cor, &wid) ) return u3_none;
+    return u3qi_twid_pow(wid, a, n);
+  }

--- a/libmath/vere/noun/jets/i/twoc.h
+++ b/libmath/vere/noun/jets/i/twoc.h
@@ -1,0 +1,116 @@
+/// @file
+///
+/// Shared two's-complement integer kernels for the numerics jets.  These are
+/// the bit-exact arithmetic primitives validated standalone (see numerics
+/// libmath/tools/twoc/), used by BOTH the scalar `/lib/twoc` jet (twoc.c) and
+/// the Lagoon `%int2` element-wise array jets (lagoon.c), so there is one
+/// validated source of truth.
+///
+/// Native paths: the op set is generated for uint64 (lanes/values <=64 bits)
+/// and unsigned __int128 (<=128) via a type-templated macro.  [msk] is the
+/// low-width-bit mask, [sb] the sign-bit position (width-1).  All arithmetic is
+/// unsigned with explicit masking, so there is no signed-overflow UB (e.g.
+/// div(min,-1) wraps to min, as in the Hoon).  GMP helpers cover widths >128.
+///
+/// REQUIRES noun.h (c3 types, gmp.h) to be included before this header.
+
+#ifndef _NOUN_JETS_I_TWOC_H
+#define _NOUN_JETS_I_TWOC_H
+
+typedef unsigned __int128 _twoc_u128;
+typedef          __int128 _twoc_s128;
+
+#define _TWOC_NATIVE(SUF, UT)                                                  \
+  static inline UT _tn_neg##SUF(UT a, UT msk) {                                \
+    return (UT)(((~a) + 1) & msk);                                             \
+  }                                                                            \
+  static inline UT _tn_sign##SUF(UT a, c3_d sb) {                              \
+    return (UT)((a >> sb) & 1);                                                \
+  }                                                                            \
+  static inline UT _tn_abs##SUF(UT a, UT msk, c3_d sb) {                       \
+    return _tn_sign##SUF(a, sb) ? _tn_neg##SUF(a, msk) : (UT)(a & msk);        \
+  }                                                                            \
+  static inline UT _tn_add##SUF(UT a, UT b, UT msk) {                          \
+    return (UT)((a + b) & msk);                                                \
+  }                                                                            \
+  static inline UT _tn_sub##SUF(UT a, UT b, UT msk) {                          \
+    return (UT)((a + _tn_neg##SUF(b, msk)) & msk);                             \
+  }                                                                            \
+  static inline UT _tn_mul##SUF(UT a, UT b, UT msk) {                          \
+    return (UT)(((a & msk) * (b & msk)) & msk);                                \
+  }                                                                            \
+  static inline UT _tn_div##SUF(UT a, UT b, UT msk, c3_d sb) {                 \
+    UT qa = _tn_abs##SUF(a, msk, sb), qb = _tn_abs##SUF(b, msk, sb);           \
+    UT q  = (UT)(qa / qb);                                                     \
+    return ( _tn_sign##SUF(a, sb) != _tn_sign##SUF(b, sb) )                    \
+           ? _tn_neg##SUF(q, msk) : (UT)(q & msk);                            \
+  }                                                                            \
+  static inline UT _tn_rem##SUF(UT a, UT b, UT msk, c3_d sb) {                 \
+    UT r = (UT)(_tn_abs##SUF(a, msk, sb) % _tn_abs##SUF(b, msk, sb));          \
+    return _tn_sign##SUF(a, sb) ? _tn_neg##SUF(r, msk) : (UT)(r & msk);        \
+  }                                                                            \
+  static inline UT _tn_pow##SUF(UT a, c3_d n, UT msk) {                        \
+    UT base = (UT)(a & msk), acc = (UT)(1 & msk);                              \
+    while ( n ) {                                                              \
+      if ( n & 1 ) acc = (UT)((acc * base) & msk);                            \
+      base = (UT)((base * base) & msk);                                        \
+      n >>= 1;                                                                 \
+    }                                                                          \
+    return acc;                                                               \
+  }                                                                            \
+  /* two's-complement order: negatives below non-negatives. */                \
+  static inline c3_t _tn_gth##SUF(UT a, UT b, c3_d sb) {                       \
+    UT sa = _tn_sign##SUF(a, sb), sbb = _tn_sign##SUF(b, sb);                  \
+    if ( sa != sbb ) return ( 0 == sa ) ? c3y : c3n;                          \
+    return ( a > b ) ? c3y : c3n;                                             \
+  }
+
+_TWOC_NATIVE(64,  c3_d)
+_TWOC_NATIVE(128, _twoc_u128)
+
+//  low-width-bit masks, guarding the width==type-size shift (UB) case.
+static inline c3_d
+_tn_msk64(c3_d wid)
+{
+  return ( wid >= 64 ) ? (c3_d)~0ull : (((c3_d)1 << wid) - 1);
+}
+static inline _twoc_u128
+_tn_msk128(c3_d wid)
+{
+  return ( wid >= 128 ) ? (~(_twoc_u128)0)
+                        : ((((_twoc_u128)1) << wid) - 1);
+}
+
+/* GMP path (widths >128).  Masking to width bits is a floored mod 2^width
+** (mpz_fdiv_r_2exp), the canonical non-negative two's-complement rep; the
+** signed value (for div/rem/compare) subtracts 2^width when the sign bit is set.
+*/
+//  r <- a mod 2^wid (non-negative).
+static inline void
+_tg_mask(mpz_t r, const mpz_t a, c3_d wid)
+{
+  mpz_fdiv_r_2exp(r, a, wid);
+}
+//  is the wid-1 (sign) bit of a masked value set?
+static inline c3_t
+_tg_sign(const mpz_t m, c3_d wid)
+{
+  return mpz_tstbit(m, wid - 1) ? c3y : c3n;
+}
+//  s <- signed value of masked m (subtract 2^wid if negative).
+static inline void
+_tg_signed(mpz_t s, const mpz_t m, c3_d wid)
+{
+  if ( _tg_sign(m, wid) == c3y ) {
+    mpz_t pow;
+    mpz_init(pow);
+    mpz_ui_pow_ui(pow, 2, wid);
+    mpz_sub(s, m, pow);
+    mpz_clear(pow);
+  }
+  else {
+    mpz_set(s, m);
+  }
+}
+
+#endif /* _NOUN_JETS_I_TWOC_H */


### PR DESCRIPTION
Jets for the `/lib/twoc` two's-complement integer library — scalar ops plus Lagoon `%int2` element-wise array ops. The runtime counterpart is urbit/vere (companion PR, linked below).

## What's here
- **Hoon hints** on `/lib/twoc` `++twid` (12 hot-path arms: `add sub neg mul div rem pow abs gth lth lte gte`). All logic lives in the width-keyed `++twid` door; the bloq-keyed `++twoc` facade re-exports its gates, so a **single `%twid` registration** fires for both `twid`-direct (`/lib/fixed`) and facade (`/lib/unum`, Lagoon) callers.
- **Master C jets** (mirrored by hand into vere): `twoc.c` dispatches on width — native `c3` (`c3_d` ≤64, `__int128` ≤128) for the bloq widths, **GNU MP** (already vendored) for arbitrary precision >128; declines to Hoon on out-of-width operands and zero divisors. Shared kernels in `twoc.h`.
- **Lagoon `%int2` array jets** (`add/sub/mul/div/mod`) in `lagoon.c`, dispatched on ray kind exactly like `%i754`, reusing the `twoc.h` kernels — one linear C pass per array op instead of the super-linear Hoon bit-packing loop.
- **Validation harnesses** (`libmath/tools/twoc`) and a vere reference (`libmath/vere/README-twoc.md`).

## Design notes
- No vendored library (unlike SoftBLAS/SoftUnum): integer arithmetic is exact natively, so there's no reproducibility forcing-function; the kernels are tiny and shared via a header.
- `%int2` array lanes are always machine widths (8/16/32/64/128), so the array path is entirely native (no GMP).

## Validation
- Standalone vs an independent two's-complement reference: **8280 native + 5692 GMP checks**, all sign edges, pass (`libmath/tools/twoc`).
- Bit-exact on a hoon-135 fakezod. Scalar firing proven two ways (sentinel + timing). `%int2` array ops verified jet == Hoon for all five ops; **~25,600× (20k lanes) to ~310,000× (200k)** over interpreted (the Hoon array path is super-linear, the jet is O(N)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)