### PR TITLE
lagoon: fix reduction-jet result shape to match +scalar-to-ray

### DIFF
--- a/lagoon/vere/noun/jets/i/lagoon.c
+++ b/lagoon/vere/noun/jets/i/lagoon.c
@@ -2434,6 +2434,24 @@
     }
   }
 
+/* Box a scalar reduction result as a ray, matching the Hoon +scalar-to-ray:
+** the shape is all-1s of the INPUT's rank (reap (lent shape) 1) -- e.g. ~[1]
+** for a rank-1 vector, ~[1 1] for a rank-2 matrix.  The data already carries
+** its leading-0x1 sentinel (== +spac on a 1-element ray).  Fixes the prior
+** hardcoded shapes (~[1 1] for min/max, ~[len 1] for dot, ~[1] for cumsum),
+** which were each correct only for one rank.
+*/
+  static u3_noun
+  _la_scalar_box(u3_noun x_shape, u3_noun x_bloq, u3_noun x_kind,
+                 u3_noun x_tail, u3_noun r_data)
+  {
+    c3_d rank = 0;  u3_noun s = x_shape;
+    while ( c3y == u3du(s) ) { rank++;  s = u3t(s); }
+    u3_noun sh = u3_nul;
+    for ( c3_d i = 0; i < rank; i++ ) sh = u3nc(0x1, sh);
+    return u3nc(u3nq(sh, u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+  }
+
   u3_noun
   u3wi_la_cumsum(u3_noun cor)
   {
@@ -2467,7 +2485,7 @@
             _set_rounding_la(rnd);
             u3_noun r_data = u3qi_la_cumsum_i754(x_data, x_shape, x_bloq);
             if (r_data == u3_none) { return u3_none; }
-            return u3nc(u3nq(u3nc(0x1, u3_nul), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+            return _la_scalar_box(x_shape, x_bloq, x_kind, x_tail, r_data);
 
           default:
             return u3_none;
@@ -2620,7 +2638,7 @@
           case c3__i754: {
             u3_noun r_data = u3qi_la_min_i754(x_data, x_shape, x_bloq);
             if (r_data == u3_none) { return u3_none; }
-            return u3nc(u3nq(u3nt(0x1, 0x1, u3_nul), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);}
+            return _la_scalar_box(x_shape, x_bloq, x_kind, x_tail, r_data);}
 
           default:
             return u3_none;
@@ -2659,7 +2677,7 @@
           case c3__i754: {
             u3_noun r_data = u3qi_la_max_i754(x_data, x_shape, x_bloq);
             if (r_data == u3_none) { return u3_none; }
-            return u3nc(u3nq(u3nt(0x1, 0x1, u3_nul), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);}
+            return _la_scalar_box(x_shape, x_bloq, x_kind, x_tail, r_data);}
 
           default:
             return u3_none;
@@ -3091,10 +3109,7 @@
             _set_rounding_la(rnd);
             u3_noun r_data = u3qi_la_dot_i754(x_data, y_data, x_shape, x_bloq);
             if (r_data == u3_none) { return u3_none; }
-            c3_d *dim_x = _get_dims(x_shape);
-            c3_d len_x0 = dim_x[0];
-            u3a_free(dim_x);
-            return u3nc(u3nq(u3nt(len_x0, 0x1, u3_nul), u3k(x_bloq), u3k(x_kind), u3k(x_tail)), r_data);
+            return _la_scalar_box(x_shape, x_bloq, x_kind, x_tail, r_data);
 
           default:
             return u3_none;


### PR DESCRIPTION
The i754 reduction jets box their scalar result with a hardcoded ray shape that's correct for only one rank, so the jet silently disagrees with the Hoon on the result meta:

| op | jet shape | `+scalar-to-ray` (Hoon) |
|---|---|---|
| `min`/`max` | `~[1 1]` | all-1s of input rank — `~[1]` for a vector |
| `dot` | `~[len 1]` | `~[1]` for rank-1 inputs |
| `cumsum` | `~[1]` | wrong for a rank-2 matrix |

`+scalar-to-ray` sets the shape to `(reap (lent shape) 1)` — all-1s of the **input's rank**. The fix adds a `_la_scalar_box` helper (all-1s of rank) and routes `cumsum`/`min`/`max`/`dot` through it, matching the Hoon for every rank. `trace` (always rank-2 → `~[1 1]`) and `diag` (returns a vector, `~[len 1]`) are correct as-is and untouched.

Found while jetting the `%int2` reductions (#67): the `%int2` path already boxes via the rank-correct shape and matches its Hoon; this brings the i754 (and any other scalar-reducing) path in line. The data/value is unchanged — only the boxed meta shape is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)