### PR TITLE
lagoon: fix +submatrix reading an upper bound of 0 as "to the end"

### DIFF
--- a/lagoon/desk/lib/lagoon.hoon
+++ b/lagoon/desk/lib/lagoon.hoon
@@ -151,7 +151,7 @@
     =/  s2=[(unit @) (unit @)]  (need s)
     ^-  (list (list @))
     ::  read bounds from the raw units, so a present upper bound of `0`
-    ::  stays distinct from an absent bound `~` ("slice to end").  (issue #8)
+    ::  stays distinct from an absent bound `~` ("slice to end").
     ::  lower defaults to 0, upper (inclusive) defaults to the last index.
     =/  lo=@  ?~(-.s2 0 u.-.s2)
     =/  hi=@  ?~(+.s2 (dec dim) u.+.s2)

--- a/lagoon/desk/lib/lagoon.hoon
+++ b/lagoon/desk/lib/lagoon.hoon
@@ -149,14 +149,13 @@
     ?~  s
       (turn (gulf 0 (dec dim)) squeeze)
     =/  s2=[(unit @) (unit @)]  (need s)
-    =/  c=^  [(fall -.s2 ~) (fall +.s2 ~)]
     ^-  (list (list @))
-    ?+    c  !!
-        [j=@ k=~]  (turn (gulf j.c (dec dim)) squeeze)
-        [j=@ k=@]  (turn (gulf j.c k.c) squeeze)
-        [j=~ k=@]  (turn (gulf 0 k.c) squeeze)
-        [~ ~]  (turn (gulf 0 (dec dim)) squeeze)
-    ==
+    ::  read bounds from the raw units, so a present upper bound of `0`
+    ::  stays distinct from an absent bound `~` ("slice to end").  (issue #8)
+    ::  lower defaults to 0, upper (inclusive) defaults to the last index.
+    =/  lo=@  ?~(-.s2 0 u.-.s2)
+    =/  hi=@  ?~(+.s2 (dec dim) u.+.s2)
+    (turn (gulf lo hi) squeeze)
     ::
     ::  calculate the shape of the result
     =/  out-shape=(list @)

--- a/lagoon/desk/tests/lib/lagoon-indexing.hoon
+++ b/lagoon/desk/tests/lib/lagoon-indexing.hoon
@@ -203,4 +203,35 @@
     %-  expect-fail
       |.((set-row:la input-magic-3x3x3-4u ~[3 3] (en-ray:la [~[1 3] 4 %uint ~] ~[~[0x0 0x1 0x2]])))
   ==
+::
+::  a 4x4 magic array is row-major 0..15, so entry [i j] = (4i + j); distinct
+::  values catch a transpose or an off-by-one that a symmetric input would hide.
+::  Slices are INCLUSIVE on both ends; an absent bound `~` means "to the end".
+++  test-submatrix-2d  ^-  tang
+  =/  input-magic-4x4-4u  (magic:la [shape=~[4 4] bloq=4 kind=%uint prec=~])
+  ;:  weld
+    ::  issue #8: a present upper bound of `0` must not read as "to the end".
+    ::  a[0:0, 2:2] is the single element [0 2] = 2, shape ~[1 1].
+    %+  expect-eq
+      !>((en-ray:la [~[1 1] 4 %uint ~] ~[~[0x2]]))
+      !>((submatrix:la ~[`[`0 `0] `[`2 `2]] input-magic-4x4-4u))
+    ::  a[1:2, 2:3] is rows 1-2, cols 2-3 = [[6 7] [10 11]], shape ~[2 2].
+    %+  expect-eq
+      !>((en-ray:la [~[2 2] 4 %uint ~] ~[~[0x6 0x7] ~[0xa 0xb]]))
+      !>((submatrix:la ~[`[`1 `2] `[`2 `3]] input-magic-4x4-4u))
+    ::  a[0:2, 3:3] is a non-square 3x1 column = [[3] [7] [11]]; a transpose
+    ::  would give shape ~[1 3] or the wrong entries.
+    %+  expect-eq
+      !>((en-ray:la [~[3 1] 4 %uint ~] ~[~[0x3] ~[0x7] ~[0xb]]))
+      !>((submatrix:la ~[`[`0 `2] `[`3 `3]] input-magic-4x4-4u))
+    ::  a[2:, :] slices rows 2-3 to the end and pads the omitted column dim,
+    ::  = [[8 9 10 11] [12 13 14 15]], shape ~[2 4] (absent upper bound).
+    %+  expect-eq
+      !>((en-ray:la [~[2 4] 4 %uint ~] ~[~[0x8 0x9 0xa 0xb] ~[0xc 0xd 0xe 0xf]]))
+      !>((submatrix:la ~[`[`2 ~]] input-magic-4x4-4u))
+    ::  a[:1, :] uses an absent lower bound = rows 0-1 = [[0..3] [4..7]].
+    %+  expect-eq
+      !>((en-ray:la [~[2 4] 4 %uint ~] ~[~[0x0 0x1 0x2 0x3] ~[0x4 0x5 0x6 0x7]]))
+      !>((submatrix:la ~[`[~ `1]] input-magic-4x4-4u))
+  ==
 --


### PR DESCRIPTION
Closes #8.

### Problem

`+submatrix` collapsed each slice bound with `(fall .. ~)` **before** the `?+` switch, turning a present upper bound of `` `0 `` into the atom `0` — indistinguishable from the absent-bound `~`. The `[j=@ k=~]` case ("slice to the end") then matched first, so any slice ending at index `0` returned the whole dimension instead of a single element:

```
> (submatrix:la:la ~[`[`0 `0] `[`2 `2]] (ones:la:la [~[4 4] 5 %i754 ~]))
shape=~[4 1]   :: should be ~[1 1] — the single element [0 2]
```

### Fix

Read the bounds straight off the raw units, so a present `0` stays distinct from an absent bound: lower defaults to `0`, upper (inclusive) defaults to the last index. Minimal change to one arm.

### Impact on callers

The only in-repo caller is `tinygrad`'s `shrink/forward`, which builds `` `[`0 `(dec a)] ``. For a size-1 dimension that is `` `[`0 `0] `` — it silently hit this bug and grabbed the whole dimension. This fix **corrects** that caller rather than breaking it. No test encoded the old behavior.

### Verification

Verified on a fake ship: the issue case now returns `~[1 1]`; asymmetric (`3x1`), transpose-sensitive, and slice-to-end cases all return correct shapes and row-major values. Adds `test-submatrix-2d` (all of `lagoon-indexing` passes, `ok=%.y`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)