### PR TITLE
math: u3_weak retyping of rd/rs/rh/rq jet samples (refcount linter)

### DIFF
--- a/libmath/vere/noun/jets/i/math.c
+++ b/libmath/vere/noun/jets/i/math.c
@@ -1853,7 +1853,7 @@ typedef int64_t  c3_ds;
   static u3_noun
   _rd_jet(u3_noun cor, float64_t (*fun)(float64_t))
   {
-    u3_noun x = u3r_at(u3x_sam, cor);
+    u3_weak x = u3r_at(u3x_sam, cor);
     if ( u3_none == x || c3n == u3ud(x) ) {
       return u3m_bail(c3__exit);
     }
@@ -2024,7 +2024,7 @@ typedef int64_t  c3_ds;
     union sing s; s.s = v; { c3_d out = (c3_d)s.c; return u3i_chubs(1, &out); }
   }
   static u3_noun _rs_jet(u3_noun cor, float32_t (*fun)(float32_t)) {
-    u3_noun x = u3r_at(u3x_sam, cor);
+    u3_weak x = u3r_at(u3x_sam, cor);
     if ( u3_none == x || c3n == u3ud(x) ) return u3m_bail(c3__exit);
     softfloat_roundingMode = softfloat_round_near_even;
     _math_rnd = _rnd_of(u3r_at(60, cor));        // door rounding r (for @rs tan)
@@ -2085,7 +2085,7 @@ typedef int64_t  c3_ds;
     union half s; s.h = v; { c3_d out = (c3_d)s.c; return u3i_chubs(1, &out); }
   }
   static u3_noun _rh_jet(u3_noun cor, float16_t (*fun)(float16_t)) {
-    u3_noun x = u3r_at(u3x_sam, cor);
+    u3_weak x = u3r_at(u3x_sam, cor);
     if ( u3_none == x || c3n == u3ud(x) ) return u3m_bail(c3__exit);
     softfloat_roundingMode = softfloat_round_near_even;   // kernels run near-even
     _math_rnd = _rnd_of(u3r_at(60, cor));        // door rounding r (for @rh tan/cbt/log-2/log-10)
@@ -2146,7 +2146,7 @@ typedef int64_t  c3_ds;
     union quad s; s.q = v; return u3i_chubs(2, &s.w[0]);
   }
   static u3_noun _rq_jet(u3_noun cor, float128_t (*fun)(float128_t)) {
-    u3_noun x = u3r_at(u3x_sam, cor);
+    u3_weak x = u3r_at(u3x_sam, cor);
     if ( u3_none == x || c3n == u3ud(x) ) return u3m_bail(c3__exit);
     softfloat_roundingMode = softfloat_round_near_even;   // kernels run near-even
     _math_rnd = _rnd_of(u3r_at(60, cor));        // door rounding r (for tan/cbt/log-2/log-10)

--- a/libmath/vere64/noun/jets/i/math.c
+++ b/libmath/vere64/noun/jets/i/math.c
@@ -1853,7 +1853,7 @@ typedef int64_t  c3_ds;
   static u3_noun
   _rd_jet(u3_noun cor, float64_t (*fun)(float64_t))
   {
-    u3_noun x = u3r_at(u3x_sam, cor);
+    u3_weak x = u3r_at(u3x_sam, cor);
     if ( u3_none == x || c3n == u3ud(x) ) {
       return u3m_bail(c3__exit);
     }
@@ -2024,7 +2024,7 @@ typedef int64_t  c3_ds;
     union sing s; s.s = v; { c3_d out = (c3_d)s.c; return u3i_chubs(1, &out); }
   }
   static u3_noun _rs_jet(u3_noun cor, float32_t (*fun)(float32_t)) {
-    u3_noun x = u3r_at(u3x_sam, cor);
+    u3_weak x = u3r_at(u3x_sam, cor);
     if ( u3_none == x || c3n == u3ud(x) ) return u3m_bail(c3__exit);
     softfloat_roundingMode = softfloat_round_near_even;
     _math_rnd = _rnd_of(u3r_at(60, cor));        // door rounding r (for @rs tan)
@@ -2085,7 +2085,7 @@ typedef int64_t  c3_ds;
     union half s; s.h = v; { c3_d out = (c3_d)s.c; return u3i_chubs(1, &out); }
   }
   static u3_noun _rh_jet(u3_noun cor, float16_t (*fun)(float16_t)) {
-    u3_noun x = u3r_at(u3x_sam, cor);
+    u3_weak x = u3r_at(u3x_sam, cor);
     if ( u3_none == x || c3n == u3ud(x) ) return u3m_bail(c3__exit);
     softfloat_roundingMode = softfloat_round_near_even;   // kernels run near-even
     _math_rnd = _rnd_of(u3r_at(60, cor));        // door rounding r (for @rh tan/cbt/log-2/log-10)
@@ -2146,7 +2146,7 @@ typedef int64_t  c3_ds;
     union quad s; s.q = v; return u3i_chubs(2, &s.w[0]);
   }
   static u3_noun _rq_jet(u3_noun cor, float128_t (*fun)(float128_t)) {
-    u3_noun x = u3r_at(u3x_sam, cor);
+    u3_weak x = u3r_at(u3x_sam, cor);
     if ( u3_none == x || c3n == u3ud(x) ) return u3m_bail(c3__exit);
     softfloat_roundingMode = softfloat_round_near_even;   // kernels run near-even
     _math_rnd = _rnd_of(u3r_at(60, cor));        // door rounding r (for tan/cbt/log-2/log-10)


### PR DESCRIPTION
Follow-up to #79 (unum), syncing the `libmath` math jets with the refcount-linter fix already carried in the vere math PR (`urbit/vere` `neal/math-jets-develop`, #1044).

## What

`_rd_jet` / `_rs_jet` / `_rh_jet` / `_rq_jet` read the door sample with `u3r_at` (a `u3_weak` product) into a plain `u3_noun` local, checking `u3_none` on the next line. Declaring the local `u3_weak` is what dozreg's refcount linter (`urbit/vere#1059`) wants. `u3_weak` is a typedef of `u3_noun`, so this is a type-annotation change with no runtime effect.

## Files

- `libmath/vere/noun/jets/i/math.c` — 4 sites (pre-vere64 twin, variadic `u3r_mean`).
- `libmath/vere64/noun/jets/i/math.c` — 4 sites (post-vere64, braced `u3r_mean`).

## Verification

After this change, `libmath/vere64/noun/jets/i/math.c` is **byte-identical** to the corrected vere math jets on `neal/math-jets-develop`. The `libmath/vere` copy keeps its pre-vere64 variadic form (the 32-bit twin); the retype is loom-agnostic.

Note: whole-file cross-repo diffs of `q.h`/`w.h`/`135/tree.c` are noisy here because numerics carries per-family jet mirrors while the vere branch is a full tree; `math.c` is the clean unit and the only file with a real math delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rqqco86RgnvtiC4axw8Px3